### PR TITLE
Added functionality to terminal which displays the talkgroup ID tags …

### DIFF
--- a/op25/gr-op25_repeater/apps/terminal.py
+++ b/op25/gr-op25_repeater/apps/terminal.py
@@ -229,9 +229,13 @@ class curses_terminal(threading.Thread):
             s = 'NAC 0x%x' % (int(current_nac))
             s += ' WACN 0x%x' % (msg[current_nac]['wacn'])
             s += ' SYSID 0x%x' % (msg[current_nac]['sysid'])
-            s += ' %f' % (msg[current_nac]['rxchan']/ 1000000.0)
-            s += '/%f' % (msg[current_nac]['txchan']/ 1000000.0)
-            s += ' tsbks %d' % (msg[current_nac]['tsbks'])
+            # Modified to clarify what these frequencies are on the control channel (e.g. send or receive)
+            s += ' RX %f' % (msg[current_nac]['rxchan']/ 1000000.0)  
+            s += ' | TX %f' % (msg[current_nac]['txchan']/ 1000000.0)
+            # As a lowly Technician-class ham (KD8VAX), I didn't know what a tsbks was and it 
+            # kinda bugged me.  It's not an easy answer to find, so let's tell the user something
+            # a *little* more English-like.
+            s += ' trnk sig blks %d' % (msg[current_nac]['tsbks'])
             freqs = sorted(msg[current_nac]['frequencies'].keys())
             s = s[:(self.maxx - 1)]
             self.top_bar.erase()

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -133,11 +133,19 @@ class trunked_system (object):
         d['last_tsbk'] = self.last_tsbk
         t = time.time()
         for f in self.voice_frequencies.keys():
-            tgs = '%s %s' % (self.voice_frequencies[f]['tgid'][0], self.voice_frequencies[f]['tgid'][1])
-            d['frequencies'][f] = 'voice frequency %f tgid(s) %s %4.1fs ago count %d' %  (f / 1000000.0, tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter'])
+            # I want to see the tags on the talkgroups that have traffic,
+            # perhaps I might want to add those to my whitelist...
+            name_1 = self.get_tag_display(self.voice_frequencies[f]['tgid'][0])
+            name_2 = self.get_tag_display(self.voice_frequencies[f]['tgid'][1])
+            if name_2 != '':
+                tgs = '%s [%s] %s [%s]' % (self.voice_frequencies[f]['tgid'][0], name_1, self.voice_frequencies[f]['tgid'][1], name_2)
+            else:
+                # I hate that 'None' thing.  Just skip outputting it.
+                tgs = '%s [%s]' % (self.voice_frequencies[f]['tgid'][0], name_1)
 
+            d['frequencies'][f] = 'voice freq: %f tgid(s) %s %4.1fs ago count %d' %  (f / 1000000.0, tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter'])
             d['frequency_data'][f] = {'tgids': self.voice_frequencies[f]['tgid'], 'last_activity': '%7.1f' % (t - self.voice_frequencies[f]['time']), 'counter': self.voice_frequencies[f]['counter']}
-	d['adjacent_data'] = self.adjacent_data
+            d['adjacent_data'] = self.adjacent_data
         return json.dumps(d)
 
     def to_string(self):
@@ -149,8 +157,16 @@ class trunked_system (object):
         s.append('')
         t = time.time()
         for f in self.voice_frequencies:
-            tgs = '%s %s' % (self.voice_frequencies[f]['tgid'][0], self.voice_frequencies[f]['tgid'][1])
-            s.append('voice frequency %f tgid(s) %s %4.1fs ago count %d' %  (f / 1000000.0, tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter']))
+            # I want to see the tags on the talkgroups that have traffic,
+            # perhaps I might want to add those to my whitelist...
+            name_1 = self.get_tag_display(self.voice_frequencies[f]['tgid'][0])
+            name_2 = self.get_tag_display(self.voice_frequencies[f]['tgid'][1])
+            if name_2 != '':
+                tgs = '%s [%s] %s [%s]' % (self.voice_frequencies[f]['tgid'][0], name_1, self.voice_frequencies[f]['tgid'][1], name_2)
+            else:
+                # I hate that 'None' thing.  Just skip outputting it.
+                tgs = '%s [%s]' % (self.voice_frequencies[f]['tgid'][0], name_1)
+            s.append('voice freq: %f tgid(s) %s %4.1fs ago count %d' %  (f / 1000000.0, tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter']))
         s.append('')
         for table in self.freq_table:
             a = self.freq_table[table]['frequency'] / 1000000.0
@@ -192,6 +208,17 @@ class trunked_system (object):
             return ""
         if tgid not in self.tgid_map:
             return "Talkgroup ID %d [0x%x]" % (tgid, tgid)
+        return self.tgid_map[tgid][0]
+
+    # This returns either an empty string if the tgid
+    # is null, a pair of question marks if there is
+    # no name for the talkgroup configured, or
+    # the name of the talkgroup.
+    def get_tag_display(self, tgid):
+        if not tgid:
+            return ""
+        if tgid not in self.tgid_map:
+            return "??"
         return self.tgid_map[tgid][0]
 
     def get_prio(self, tgid):


### PR DESCRIPTION
…if known.

Eliminated output of second TGID from frequency if not present (removing the 'None' string)
Changed output of frequency/nac information on top so as to make the frequencies
more clear (e.g. RX/TX).  Also altered tsbks to 'trnk sig blks'.

-=-=-
Hi, Boatbod, Geoff Gariepy (KD8VAX) here.
I really like using OP25, I just recently got it up and running on a RPI and have been enjoying learning about it.  
A couple of things about using it just weren't clear to me: what is a tsbks?  What's the 'None' in the list of active frequencies?  Wouldn't it be nice to see what tags those TGIDs had if they were in the TSV?

So a few hours of figuring things out and I've made a few small changes which I hope you will consider merging.  I believe it will help make OP25 a little more clear for newbs like me, and maybe a little nicer overall.

Thanks for having a look.

--Geoff