### PR TITLE
cmake: work around CMake UseSwig behavior change

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -118,7 +118,7 @@ endfunction(GR_UNIQUE_TARGET)
 ########################################################################
 # Install python sources (also builds and installs byte-compiled python)
 ########################################################################
-function(GR_PYTHON_INSTALL)
+function(GR_PYTHON_INSTALL name)
     include(CMakeParseArgumentsCopy)
     CMAKE_PARSE_ARGUMENTS(GR_PYTHON_INSTALL "" "DESTINATION;COMPONENT" "FILES;PROGRAMS" ${ARGN})
 
@@ -155,6 +155,15 @@ function(GR_PYTHON_INSTALL)
             file(MAKE_DIRECTORY ${pygen_path})
 
         endforeach(pyfile)
+
+        # XXX(cmake): This can be relaxed once CMake Issue #20067 is fixed.
+        # https://gitlab.kitware.com/cmake/cmake/issues/20067
+        if (CMAKE_VERSION VERSION_LESS "3.11" OR
+            NOT CMAKE_GENERATOR MATCHES "Makefiles")
+            set(depends_files ${pysrcfiles})
+        else ()
+            set(depends_files ${name}_swig_compilation)
+        endif ()
 
         #the command to generate the pyc files
         add_custom_command(

--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -184,7 +184,8 @@ macro(GR_SWIG_INSTALL)
         )
 
         include(GrPython)
-        GR_PYTHON_INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${name}.py
+        GR_PYTHON_INSTALL(${name}
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/${name}.py
             DESTINATION ${GR_SWIG_INSTALL_DESTINATION}
             COMPONENT ${GR_SWIG_INSTALL_COMPONENT}
         )


### PR DESCRIPTION
CMake 3.11 included a change which made the dependency directly on the
files not work in Makefile-based generators. Instead, depend on the
custom target provided in that case.

Fixes: #25