### PR TITLE
colorize curses output for terminal user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Untracked files in op25 hierachy
 build/
 *.pyc
+port*

--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+This fork colorizes the curses terminal view for easier identification of TGIDs based
+on what tags are entered into the trunk ID tag mapping file tsv file.  Any TGID with 
+"PD" in the tag name will colorize TGID output in active field as Blue, "FD" as Red, 
+"EMS" as Green, "DPW" as yellow, and any tag in that file w/o those descriptors will be
+ white. Descriptors may be in any position in talkgroup name, but must be as listed
+ (sans quotes), talkgroup tag file must be declared in trunk file to work.
+
 Forked from git://git.osmocom.org/op25 "max" branch on 9/10/2017
 Up to date with "max" branch as of 3/3/2018
 

--- a/op25/gr-op25_repeater/apps/.gitignore
+++ b/op25/gr-op25_repeater/apps/.gitignore
@@ -7,6 +7,9 @@ stderr.2
 *.sh
 *.txt
 *.liq
+port*
+*.wav
+*.log
 
 # Tracked files that would otherwise be excluded
 !op25.sh

--- a/op25/gr-op25_repeater/apps/trunk.tsv
+++ b/op25/gr-op25_repeater/apps/trunk.tsv
@@ -1,2 +1,2 @@
 "Sysname"	"Control Channel List"	"Offset"	"NAC"	"Modulation"	"TGID Tags File"	"Whitelist"	"Blacklist"	"Center Frequency"
-"P25 SYSTEM"	"876.54320"	"0"	"0"	"cqpsk"	""	""	""	""
+"default"	"123.4567"	"0"	"0x1"	"cqpsk"	""	""	""	""

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -858,8 +858,8 @@ class rx_ctl (object):
         self.setup_config(configs)
 
     def build_config(self, config_filename):
-        import configparser
-        config = configparser.ConfigParser()
+        import ConfigParser
+        config = ConfigParser.ConfigParser()
         config.read(config_filename)
         configs = {}
         for section in config.sections():


### PR DESCRIPTION
Colorize terminal curses-based output for terminal users.    TGID Tag in active-2 window will now reflect color based on the following

1. trunking.tsv file is correctly populated for system in use, and called via -t
2. tgid.tsv (is populated w/ TGIDs to scan, and TGIDs have prerequisite tags in them) is called from trunking.tsv field.
3. terminal supports color changing, and is enabled at the system level.

tag coloring description

1. PD = Blue
2. FD = Red
3. EMS = Green
4. DPW = Yellow
5. all others = White

These changes allow for rapid identification of TGID activity via color-coding.