### PR TITLE
Relative import syntax

### DIFF
--- a/op25/gr-op25/python/__init__.py
+++ b/op25/gr-op25/python/__init__.py
@@ -42,7 +42,7 @@ if _RTLD_GLOBAL != 0:
 
 
 # import swig generated symbols into the op25 namespace
-from op25_swig import *
+from .op25_swig import *
 
 # import any pure python here
 #

--- a/op25/gr-op25_repeater/python/__init__.py
+++ b/op25/gr-op25_repeater/python/__init__.py
@@ -42,7 +42,7 @@ if _RTLD_GLOBAL != 0:
 
 
 # import swig generated symbols into the op25_repeater namespace
-from op25_repeater_swig import *
+from .op25_repeater_swig import *
 
 # import any pure python here
 #


### PR DESCRIPTION
For importing a sibling module in a package, explicit relative import syntax is needed now (the syntax was [introduced in python 2.5 or so](https://www.python.org/dev/peps/pep-0328/), but the deprecated ambiguous syntax was supported for backwards compatibility until recent pythons)