### PR TITLE
Python 3 support for SmartNet (multi_rx)

### DIFF
--- a/op25/gr-op25_repeater/apps/gr_gnuplot.py
+++ b/op25/gr-op25_repeater/apps/gr_gnuplot.py
@@ -74,7 +74,7 @@ class wrap_gp(object):
     def attach_gp(self):
         args = (GNUPLOT, '-noraise')
         exe  = GNUPLOT
-        self.gp = subprocess.Popen(args, executable=exe, stdin=subprocess.PIPE)
+        self.gp = subprocess.Popen(args, executable=exe, stdin=subprocess.PIPE, universal_newlines=True)
 
     def set_sps(self, sps):
         self.sps = sps

--- a/op25/gr-op25_repeater/apps/multi_rx.py
+++ b/op25/gr-op25_repeater/apps/multi_rx.py
@@ -644,7 +644,7 @@ class rx_block (gr.top_block):
 
     def process_qmsg(self, msg):            # Handle UI requests
         RX_COMMANDS = 'skip lockout hold whitelist reload'
-        s = msg.to_string()
+        s = msg.to_string().decode('utf-8')
         if s == 'quit':
             return True
         elif s == 'update':                 # UI initiated update request
@@ -742,17 +742,6 @@ class du_queue_watcher(threading.Thread):
 
 class rx_main(object):
     def __init__(self):
-        def byteify(input):    # thx so
-            if isinstance(input, dict):
-                return {byteify(key): byteify(value)
-                        for key, value in list(input.items())}
-            elif isinstance(input, list):
-                return [byteify(element) for element in input]
-            elif isinstance(input, str):
-                return input.encode('utf-8')
-            else:
-                return input
-
         self.keep_running = True
 
         # command line argument parsing
@@ -774,7 +763,7 @@ class rx_main(object):
                 parser.print_help()
                 exit(1)
             config = json.loads(open(options.config_file).read())
-        self.tb = rx_block(options.verbosity, config = byteify(config))
+        self.tb = rx_block(options.verbosity, config)
         self.q_watcher = du_queue_watcher(self.tb.ui_out_q, self.process_qmsg)
 
     def process_qmsg(self, msg):


### PR DESCRIPTION
Hello!

I've been trying to get OP25 running on Debian testing with Python 3/GNU Radio 3.8 (similar to #29). I'm interested in a SmartZone system specifically (thanks for recently adding support!) and I've managed to get `multi_rx.py` working.

The changes in this PR should be backwards compatible with Python 2 (it worked when I tested on a Raspberry Pi) but to actually run `multi_rx.py` with GNU Radio 3.8 / Python 3 I had to apply [EvanKrall's patch](https://gist.github.com/EvanKrall/bd9a6088ce37b2d67b17e80716c04865) and the changes in #57 as well.

(I was going to include some changes to `sockaudio.py` but I decided not to because I haven't been able to successfully stream audio with it. It works if I just use netcat to pipe the raw data to `play`, though.)

Let me know what you think! My Python is a bit rusty but I'd love to help add Python 3 support to more bits of OP25.