### PR TITLE
Handle textual I/O in Python 3.

### DIFF
--- a/op25/gr-op25_repeater/apps/rx.py
+++ b/op25/gr-op25_repeater/apps/rx.py
@@ -875,7 +875,7 @@ class p25_rx_block (gr.top_block):
     def process_qmsg(self, msg):
         # return true = end top block
         RX_COMMANDS = 'skip lockout hold whitelist reload'
-        s = msg.to_string()
+        s = msg.to_string().decode('ascii')
         if s == 'quit': return True
         elif s == 'update':
             self.freq_update()

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -868,7 +868,7 @@ class rx_ctl (object):
         import csv
         hdrmap = []
         configs = {}
-        with open(tsv_filename, 'rb') as csvfile:
+        with open(tsv_filename, 'r') as csvfile:
             sreader = csv.reader(csvfile, delimiter='\t', quotechar='"', quoting=csv.QUOTE_ALL)
             for row in sreader:
                 if row[0].startswith('#'):
@@ -969,7 +969,7 @@ class rx_ctl (object):
                     self.configs[nac][k] = get_int_dict(configs[nac][k])
             if 'tgid_tags_file' in configs[nac]:
                 import csv
-                with open(configs[nac]['tgid_tags_file'], 'rb') as csvfile:
+                with open(configs[nac]['tgid_tags_file'], 'r') as csvfile:
                     sreader = csv.reader(csvfile, delimiter='\t', quotechar='"', quoting=csv.QUOTE_ALL)
                     for row in sreader:
                         try:


### PR DESCRIPTION
This fixes a few string/bytes inconsistencies when running under python 3.

There's another needed fix in `gr_gnuplot.py`, which I left out of this PR because it's redundant with PR #58 .
