### PR TITLE
Add missing io import

### DIFF
--- a/op25/gr-op25_repeater/apps/rx.py
+++ b/op25/gr-op25_repeater/apps/rx.py
@@ -30,6 +30,7 @@ import os
 import pickle
 import sys
 import threading
+import io
 import math
 import numpy
 import time


### PR DESCRIPTION
Receiving an error in rx.py that io is not defined. Importing it in rx.py fixed the error.