### PR TITLE
Added systemd service file examples for multi_rx autostart

### DIFF
--- a/op25-multi_rx.service
+++ b/op25-multi_rx.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=op25-multi_rx
+After=syslog.target network.target nss-lookup.target network-online.target
+Requires=network-online.target
+
+[Service]
+User=1000
+Group=1000
+WorkingDirectory=/home/pi/op25/op25/gr-op25_repeater/apps
+ExecStart=/bin/bash -- op25-multi_rx.sh
+RestartSec=5
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/op25-multi_rx.sh
+++ b/op25-multi_rx.sh
@@ -1,0 +1,1 @@
+./multi_rx.py -v 1 -c p25_rtl_example.json 2> stderr.2


### PR DESCRIPTION
Might also be worth updating documentation with regards to service examples and rx_multi.py for systemd novices.