### PR TITLE
Modify terminal.py to log to a text file.

### DIFF
--- a/op25/gr-op25_repeater/apps/cfgtrunk.py
+++ b/op25/gr-op25_repeater/apps/cfgtrunk.py
@@ -71,7 +71,7 @@ def read_configs(tsv_filename):
                         hdrmap.append(hdr)
                     continue
                 fields = {}
-                if (len(row) < 4) or (len(row) > 9):
+                if (len(row) < 4) or (len(row) > 10):
                     sys.stderr.write("Skipping invalid row in %s: %s\n" % (tsv_filename, row))
                     continue
                 for i in range(len(row)):

--- a/op25/gr-op25_repeater/apps/helper_funcs.py
+++ b/op25/gr-op25_repeater/apps/helper_funcs.py
@@ -128,7 +128,7 @@ def read_tsv_file(tsv_filename, key):
                     hdrmap.append(hdr)
                 continue
             fields = {}
-            if (len(row) < 4) or (len(row) > 9):
+            if (len(row) < 4) or (len(row) > 10):
                 sys.stderr.write("Skipping invalid row in %s: %s\n" % (tsv_filename, row))
                 continue
             for i in range(len(row)):

--- a/op25/gr-op25_repeater/apps/terminal.py
+++ b/op25/gr-op25_repeater/apps/terminal.py
@@ -91,7 +91,8 @@ class curses_terminal(threading.Thread):
         self.sock = sock
         self.sm_step = 100
         self.lg_step = 1200
-        self.send_command('get_terminal_config', 0, 0)
+        # XXX - this seems to confuse rx.py at startup
+        #self.send_command('get_terminal_config', 0, 0)
         self.start()
 
     def get_terminal_type(self):


### PR DESCRIPTION
Modify `terminal.py` to log details of each transmission to a text file. The file name and location are unfortunately hard-coded - `op25-scanner.log` in the same directory that `terminal.py` is in. Closes issue #159 .

**INCLUDES** the changes in the previous pull request, #158 , that address issue #157 .