### PR TITLE
Fix for spdlog bundled fmt being removed in most sane distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,9 +134,12 @@ if ("${Gnuradio_VERSION}" VERSION_LESS "2.7.0")
 elseif ("${Gnuradio_VERSION}" VERSION_LESS "3.8.0")
     set(OP25_PYTHON_VER 2)
 else()
-    set(OP25_PYTHON_VER 3) 
+    set(OP25_PYTHON_VER 3)
 endif()
 MESSAGE(STATUS "Configuring for Python ${OP25_PYTHON_VER}")
+if(NOT EXISTS /usr/include/spdlog/fmt/bundled)
+  ADD_DEFINITIONS(-DSPDLOG_FMT_EXTERNAL=ON)
+endif()
 
 execute_process(COMMAND python${OP25_PYTHON_VER} -c "
 import os


### PR DESCRIPTION
SPDLog started bundling fmt, which gets removed by linux distributions with sane package guidelines (e.g. Fedora or Arch etc.).  This patch resolves build failures on those distributions.

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>