### PR TITLE
use iterators for std::fill, fix out of bounds access

### DIFF
--- a/op25/gr-op25/lib/decoder_bf_impl.cc
+++ b/op25/gr-op25/lib/decoder_bf_impl.cc
@@ -78,10 +78,9 @@ namespace gr {
        * samples/s. That's a work rate of 3/5 or 0.6. If no audio
        * output is available we'll produce silence.
        */
-      const size_t nof_inputs = ninput_items_required.size();
       const int nsamples_reqd = .6 * noutput_items;
-      fill(&ninput_items_required[0],
-	   &ninput_items_required[nof_inputs],
+      fill(ninput_items_required.begin(),
+	   ninput_items_required.end(),
 	   nsamples_reqd);
     }
 

--- a/op25/gr-op25/lib/fsk4_demod_ff_impl.cc
+++ b/op25/gr-op25/lib/fsk4_demod_ff_impl.cc
@@ -232,7 +232,7 @@ namespace gr {
     fsk4_demod_ff_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
     {
       const int nof_samples_reqd = static_cast<int>(ceil(d_block_rate * noutput_items));
-      std::fill(&ninput_items_required[0], &ninput_items_required[ninput_items_required.size()], nof_samples_reqd);
+      std::fill(ninput_items_required.begin(), ninput_items_required.end(), nof_samples_reqd);
     }
 
     int

--- a/op25/gr-op25_repeater/lib/ambe_encoder_sb_impl.cc
+++ b/op25/gr-op25_repeater/lib/ambe_encoder_sb_impl.cc
@@ -79,9 +79,8 @@ ambe_encoder_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_it
 {
    /* produces 1 36-byte-block sample per 160 samples input
     */
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_samples_reqd = 160.0 * (nof_output_items);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/op25/gr-op25_repeater/lib/dmr_bs_tx_bb_impl.cc
+++ b/op25/gr-op25_repeater/lib/dmr_bs_tx_bb_impl.cc
@@ -368,10 +368,9 @@ dmr_bs_tx_bb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items
 {
    // reads three ambe codewords (216 bits = 108 dibits) for each 144 dibit output burst
    // the three codewords though are only read from one of the two inputs per burst
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_bursts = nof_output_items / 144.0;
    const int nof_samples_reqd = 3 * ((nof_bursts+1)>>1);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/op25/gr-op25_repeater/lib/dstar_tx_sb_impl.cc
+++ b/op25/gr-op25_repeater/lib/dstar_tx_sb_impl.cc
@@ -152,10 +152,9 @@ void
 dstar_tx_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd)
 {
    // each 96-bit output frame contains one voice code word=160 samples input
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_vcw = nof_output_items / 96.0;
    const int nof_samples_reqd = nof_vcw * 160;
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/op25/gr-op25_repeater/lib/vocoder_impl.cc
+++ b/op25/gr-op25_repeater/lib/vocoder_impl.cc
@@ -99,9 +99,8 @@ vocoder_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd
     *
     * Thanks to Matt Mills for catching a bug where this value wasn't set correctly
     */
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_samples_reqd = (opt_encode_flag) ? (1.66667 * nof_output_items) : (0.2 * nof_output_items);
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 

--- a/op25/gr-op25_repeater/lib/ysf_tx_sb_impl.cc
+++ b/op25/gr-op25_repeater/lib/ysf_tx_sb_impl.cc
@@ -378,10 +378,9 @@ void
 ysf_tx_sb_impl::forecast(int nof_output_items, gr_vector_int &nof_input_items_reqd)
 {
    // each 480-dibit output frame contains five voice code words=800 samples
-   const size_t nof_inputs = nof_input_items_reqd.size();
    const int nof_vcw = nof_output_items / 480.0;
    const int nof_samples_reqd = nof_vcw * 5 * 160;
-   std::fill(&nof_input_items_reqd[0], &nof_input_items_reqd[nof_inputs], nof_samples_reqd);
+   std::fill(nof_input_items_reqd.begin(), nof_input_items_reqd.end(), nof_samples_reqd);
 }
 
 int 


### PR DESCRIPTION
See also robotastic/trunk-recorder#782

Even though you are only using the address of the `vector[0]`, you were still dereferencing it first via `operator[]`, which is UB if the index does not exist.
Using iterators fixes this as `vector.begin()` returns `vector.end()` if `vector.size()` is 0.

CC @ZeroChaos-