### PR TITLE
Fix reg and de-reg system ID parsing

### DIFF
--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -740,15 +740,15 @@ class p25_system(object):
         elif opcode == 0x2c:   # u_reg_rsp
             mfrid  = (tsbk >> 80) & 0xff
             rv     = (tsbk >> 76) & 0x3
-            syid   = (tsbk >> 64) & 0xffff
-            sid   = (tsbk >> 40) & 0xffffff
+            syid   = (tsbk >> 64) & 0xfff
+            sid    = (tsbk >> 40) & 0xffffff
             sa     = (tsbk >> 16) & 0xffffff
             if self.debug >= 10:
                 sys.stderr.write('%s [%d] tsbk(0x2c) u_reg_rsp: mfid: 0x%x rv: %d syid: 0x%x sid: %d sa: %d\n' % (log_ts.get(), m_rxid, mfrid, rv, syid, sid, sa))
         elif opcode == 0x2f:   # u_de_reg_ack
             mfrid  = (tsbk >> 80) & 0xff
             wacn   = (tsbk >> 52) & 0xfffff
-            syid   = (tsbk >> 40) & 0xffff
+            syid   = (tsbk >> 40) & 0xfff
             sid    = (tsbk >> 16) & 0xffffff
             if self.debug >= 10:
                 sys.stderr.write('%s [%d] tsbk(0x2f) u_de_reg_ack: mfid: 0x%x wacn: 0x%x syid: 0x%x sid: %d\n' % (log_ts.get(), m_rxid, mfrid, wacn, syid, sid))

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -656,7 +656,7 @@ class trunked_system (object):
             mfrid  = (tsbk >> 80) & 0xff
             rv     = (tsbk >> 76) & 0x3
             syid   = (tsbk >> 64) & 0xfff
-            sid   = (tsbk >> 40) & 0xffffff
+            sid    = (tsbk >> 40) & 0xffffff
             sa     = (tsbk >> 16) & 0xffffff
             if self.debug >= 10:
                 sys.stderr.write('%s [0] tsbk(0x2c) u_reg_rsp: mfid: 0x%x rv: %d syid: 0x%x sid: %d sa: %d\n' % (log_ts.get(), mfrid, rv, syid, sid, sa))

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -655,7 +655,7 @@ class trunked_system (object):
         elif opcode == 0x2c:   # u_reg_rsp
             mfrid  = (tsbk >> 80) & 0xff
             rv     = (tsbk >> 76) & 0x3
-            syid   = (tsbk >> 64) & 0xffff
+            syid   = (tsbk >> 64) & 0xfff
             sid   = (tsbk >> 40) & 0xffffff
             sa     = (tsbk >> 16) & 0xffffff
             if self.debug >= 10:
@@ -663,7 +663,7 @@ class trunked_system (object):
         elif opcode == 0x2f:   # u_de_reg_ack
             mfrid  = (tsbk >> 80) & 0xff
             wacn   = (tsbk >> 52) & 0xfffff
-            syid   = (tsbk >> 40) & 0xffff
+            syid   = (tsbk >> 40) & 0xfff
             sid    = (tsbk >> 16) & 0xffffff
             if self.debug >= 10:
                 sys.stderr.write('%s [0] tsbk(0x2f) u_de_reg_ack: mfid: 0x%x wacn: 0x%x syid: 0x%x sid: %d\n' % (log_ts.get(), mfrid, wacn, syid, sid))


### PR DESCRIPTION
Current system ID parsing in `u_reg_rsp` and `u_de_reg_ack` incorrectly parses system ID as a 16-bit value when it should be a 12-bit value. This results in the RV being prepended to the system ID in cases where the RV is non-zero (various failures).