### PR TITLE
SmartNet: first substantial improvement of decoding and display

### DIFF
--- a/op25/gr-op25_repeater/apps/README-smartnet
+++ b/op25/gr-op25_repeater/apps/README-smartnet
@@ -24,7 +24,7 @@ Motorola Type II SmartNet/SmartZone systems send a channel identifier command in
 
 In the USA, most legacy 800Mhz systems should be configured with bandplan set to `800_reband` with no further information necessary.  VHF and UHF systems are considered "Other Band Trunking" (OBT), and require the bandplan set to `OBT` along with values populated in the `bp_` frequency, spacing, and offset parameters.  These can usually be found on the RadioReference wiki as "Custom Frequency Tables" or "Custom Band Plan".
 
-OBT systems may optionally have the nine `bp_tx_` parameters set as well.  These behave identically to the `bp_` parameters but are used to translate subscriber transmit (uplink) numeric IDs to actual frequencies.  This is not required for simply listening to a system; the functionality is added for more involved debugging of outbound service words (OSWs) as may be necessary for a system admin.  Transmit frequencies are logged to stderr along with detailed OSW meanings when verbosity is set to at least 11, or full raw OSWs can be logged with a verbosity of at least 13.
+OBT systems may optionally have the nine `bp_tx_` parameters set as well; if not set they default to values based on the `bp_` parameters.  These behave identically to the `bp_` parameters but are used to translate subscriber transmit (uplink) numeric IDs to actual frequencies.  This is not required for simply listening to a system; the functionality is added for more involved debugging of outbound service words (OSWs) as may be necessary for a system admin.  Transmit frequencies are logged to stderr along with detailed OSW meanings when verbosity is set to at least 11, or full raw OSWs can be logged with a verbosity of at least 13.
 
 Example 1
 ---------
@@ -36,24 +36,7 @@ Anne Arundel County (https://www.radioreference.com/apps/db/?sid=187)
 
 Example 2
 ---------
-OBT (UHF) system with receive-only parameters populated
-
-Federal Medical Center Devens (https://www.radioreference.com/db/sid/6990)
-    "control_channel_list": "406.8125,407.4125,408.25,409.0125",
-    "bandplan": "OBT",
-    "bp_base": 406.0,
-    "bp_base_spacing": 0.0125,
-    "bp_base_offset": 380,
-    "bp_mid": 408.0,
-    "bp_mid_spacing": 0.0125,
-    "bp_mid_offset": 572,
-    "bp_high": 409.0,
-    "bp_high_spacing": 0.0125,
-    "bp_high_offset": 712
-
-Example 3
----------
-OBT (VHF) system with subscriber uplink parameters populated
+OBT (VHF) system with receive-only parameters populated
 
 Bell FleetNet Ontario (https://www.radioreference.com/apps/db/?sid=2560)
     "control_channel_list": "142.500",
@@ -66,16 +49,27 @@ Bell FleetNet Ontario (https://www.radioreference.com/apps/db/?sid=2560)
     "bp_mid_offset": 579,
     "bp_high": 154.320,
     "bp_high_spacing": 0.015,
-    "bp_high_offset": 632,
-    "bp_tx_base": 141.015,
-    "bp_tx_base_spacing": 0.015,
+    "bp_high_offset": 632
+
+Example 3
+---------
+OBT (UHF) system with subscriber uplink parameters populated
+
+Federal Medical Center Devens (https://www.radioreference.com/db/sid/6990)
+    "control_channel_list": "406.8125,407.4125,408.25,409.0125",
+    "bandplan": "OBT",
+    "bp_base": 406.0,
+    "bp_base_spacing": 0.0125,
+    "bp_base_offset": 380,
+    "bp_mid": 409.0,
+    "bp_mid_spacing": 0.0125,
+    "bp_mid_offset": 744,
+    "bp_tx_base": 415.0,
+    "bp_tx_base_spacing": 0.0125,
     "bp_tx_base_offset": 0,
-    "bp_tx_mid": 151.730,
-    "bp_tx_mid_spacing": 0.015,
-    "bp_tx_mid_offset": 199,
-    "bp_tx_high": 154.320,
-    "bp_tx_high_spacing": 0.015,
-    "bp_tx_high_offset": 252
+    "bp_tx_mid": 418.0,
+    "bp_tx_mid_spacing": 0.0125,
+    "bp_tx_mid_offset": 364
 
 Startup
 -------

--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -1525,7 +1525,7 @@ class p25_system(object):
                 vc_tgs = "[%5s|%5s]" % (vc1, vc0)
             d['frequencies'][f] = 'voice freq %f, active tgids %s, last seen %4.1fs, count %d' %  ((f/1e6), vc_tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter'])
 
-            d['frequency_data'][f] = {'tgids': self.voice_frequencies[f]['tgid'], 'last_activity': '%7.1f' % (t - self.voice_frequencies[f]['time']), 'counter': self.voice_frequencies[f]['counter']}
+            d['frequency_data'][f] = {'type': 'voice', 'tgids': self.voice_frequencies[f]['tgid'], 'last_activity': '%7.1f' % (t - self.voice_frequencies[f]['time']), 'counter': self.voice_frequencies[f]['counter']}
         d['adjacent_data'] = self.adjacent_data
         return json.dumps(d)
 

--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -1494,6 +1494,7 @@ class p25_system(object):
 
     def to_json(self):  # ugly but required for compatibility with P25 trunking and terminal modules
         d = {}
+        d['type']           = 'p25'
         d['system']         = self.sysname
         d['top_line']       = 'P25 NAC 0x%x' % (self.nac)
         d['top_line']      += ' WACN 0x%x' % (self.ns_wacn if self.ns_wacn is not None else 0)

--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -1471,7 +1471,7 @@ class p25_system(object):
                 updated += 1
                 del self.patches[sg]
                 if self.debug >= 5:
-                    sys.stderr.write("%s [%s] expired_patches: expiring patch sg(%d)\n" % (log_ts.get(), self.sysname, sg))
+                    sys.stderr.write("%s [%s] expire_patches: expiring patch sg(%d)\n" % (log_ts.get(), self.sysname, sg))
         return updated
 
     def get_rid_tag(self, srcaddr):

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -796,7 +796,7 @@ class osw_receiver(object):
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW group voice grant command
-            elif osw1_ch_rx and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+            elif osw2_ch_tx and osw1_ch_rx and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
                 mode = 0 if osw2_grp else 1
                 type_str = "ANALOG" if osw2_grp else "DIGITAL"
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -321,12 +321,14 @@ class osw_receiver(object):
         rc |= self.expire_talkgroups(curr_time)
         return rc
 
-    def is_obt_system(self): # Is the current config for an OBT system
+    # Is the current config for an OBT system
+    def is_obt_system(self):
         bandplan = from_dict(self.config, 'bandplan', "800_reband")
         band = bandplan[:3]
         return band == "OBT" or band == "400" # Still accept '400' for backwards compatibility
 
-    def get_expected_obt_tx_freq(self, rx_freq): # Attempt to auto-compute transmit offsets based on typical USA/Canada band plans
+    # Attempt to auto-compute transmit offsets based on typical USA/Canada band plans
+    def get_expected_obt_tx_freq(self, rx_freq):
         # VHF has no standard transmit offset so OBT systems usually use the same base freq, and assign different channel numbers
         if rx_freq >= 136.0 and rx_freq < 174.0:
             return rx_freq
@@ -348,7 +350,8 @@ class osw_receiver(object):
         # Unknown frequency range, so we can't get an expected value
         return 0.0
 
-    def is_chan(self, chan, is_tx=False): # Is the 'chan' a valid frequency (is_tx for OBT explicit tx channel assignments)
+    # Is the 'chan' a valid frequency; uplink channel if is_tx=True (mostly applicable for OBT systems with explicit tx channel assignments)
+    def is_chan(self, chan, is_tx=False):
         bandplan = from_dict(self.config, 'bandplan', "800_reband")
         band = bandplan[:3]
         subtype = bandplan[3:len(bandplan)].lower().lstrip("_-:")
@@ -375,7 +378,8 @@ class osw_receiver(object):
 
         return False
 
-    def get_freq(self, chan, is_tx=False): # Convert 'chan' into band-dependent frequency (is_tx for debugging uplink frequencies)
+    # Convert 'chan' into band-dependent frequency; uplink frequency if is_tx=True (mostly applicable for OBT systems with explicit tx channel assignments)
+    def get_freq(self, chan, is_tx=False):
         # Short-circuit invalid frequencies
         if not self.is_chan(chan, is_tx):
             if self.debug >= 5:
@@ -478,10 +482,12 @@ class osw_receiver(object):
         # Round to 5 decimal places to eliminate accumulated floating point errors
         return round(freq, 5)
 
-    def get_group_str(self, is_group): # Convert is-group bit to human-readable string
+    # Convert is-group bit to human-readable string
+    def get_group_str(self, is_group):
         return "G" if is_group != 0 else "I"
 
-    def get_band(self, band): # Convert index into string of the frequency band
+    # Convert index into string of the frequency band
+    def get_band(self, band):
         if band == 0:
             return "800 international splinter"
         elif band == 1:
@@ -499,7 +505,8 @@ class osw_receiver(object):
         else:
             return "%s" % (band)
 
-    def get_connect_tone(self, connect_tone_index): # Convert index into connect tone (Hz)
+    # Convert index into connect tone (Hz)
+    def get_connect_tone(self, connect_tone_index):
         if connect_tone_index == 0:
             return 105.88
         elif connect_tone_index == 1:
@@ -519,7 +526,8 @@ class osw_receiver(object):
         else:
             return None
 
-    def get_features_str(self, feat): # Convert features into a string showing the meaning
+    # Convert features into a string showing the meaning
+    def get_features_str(self, feat):
         failsoft    = (feat & 0x31 == 0)
         voc         = (feat & 0x20) >> 5
         wide_area   = (feat & 0x10) >> 4
@@ -550,7 +558,8 @@ class osw_receiver(object):
 
         return feat_str[:-2]
 
-    def get_call_options_str(self, tgid): # Convert TGID into a string showing the call options
+    # Convert TGID into a string showing the call options; exclude "CLEAR" prefix if include_clear=False
+    def get_call_options_str(self, tgid, include_clear=True):
         is_encrypted = (tgid & 0x8) >> 3
         options      = (tgid & 0x7)
 

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -613,6 +613,61 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET DEAFFILIATION src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Failsoft assign
+                        elif osw1_addr == 0x8301:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET FAILSOFT ASSIGN tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Selector unlocked
+                        elif osw1_addr == 0x8302:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET SELECTOR UNLOCKED src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Selector locked
+                        elif osw1_addr == 0x8303:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET SELECTOR LOCKED src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Failsoft canceled
+                        elif osw1_addr == 0x8305:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET FAILSOFT CANCELED src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Radio inhibited
+                        elif osw1_addr == 0x8307:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET RADIO INHIBITED src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Radio uninhibited
+                        elif osw1_addr == 0x8308:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET RADIO UNINHIBITED src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Selector unlock
+                        elif osw1_addr == 0x8312:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET SELECTOR UNLOCK tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Selector lock
+                        elif osw1_addr == 0x8313:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET SELECTOR LOCK tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Failsoft cancel
+                        elif osw1_addr == 0x8315:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET FAILSOFT CANCEL tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Radio inhibit
+                        elif osw1_addr == 0x8317:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET RADIO INHIBIT tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Radio uninhibit
+                        elif osw1_addr == 0x8318:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET RADIO UNINHIBIT tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
                         # Unknown extended function
                         else:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1181,9 +1181,9 @@ class osw_receiver(object):
                 cvsd_echo_delay  = (data & 0x3e) >> 1
                 bit0             = (data & 0x1)
                 # Try to make it more human-readable
-                secure_str       = "None" if no_secure else ("Upgraded" if secure_upgrade else "Standard")
-                data_str         = "None" if no_data else ("Full" if full_data else "Reduced")
-                otar_str         = "Reduced" if reduced_otar else "Full"
+                secure_str       = "none" if no_secure else ("upgraded" if secure_upgrade else "standard")
+                data_str         = "none" if no_data else ("full" if full_data else "reduced")
+                otar_str         = "reduced" if reduced_otar else "full"
                 multikey_buf_str = "B" if multikey_buf_b else "A"
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS data(%s) secure(%s)" % (log_ts.get(), self.msgq_id, scope, data_str, secure_str))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -706,13 +706,6 @@ class osw_receiver(object):
                 rc |= self.update_voice_frequency(vc_freq, dst_tgid, src_rid, mode=0, ts=osw1_t)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET ANALOG %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_freq))
-            elif osw1_ch_rx and not osw1_grp and ((osw1_addr & 0xff00) == 0x1f00):
-                system = osw2_addr
-                cc_freq = osw1_f_rx
-                self.rx_sys_id = system
-                self.rx_cc_freq = cc_freq * 1e6
-                if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET CONTROL CHANNEL 2 sys(0x%04x) cc_freq(%f)\n" % (log_ts.get(), self.msgq_id, system, cc_freq))
             # One of many possible two- or three-OSW meanings...
             elif osw1_cmd == 0x30b:
                 # Get next OSW in the queue

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -840,6 +840,12 @@ class osw_receiver(object):
                             code = osw1_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, code))
+            # Two-OSW dynamic regroup
+            elif osw1_cmd == 0x30a:
+                src_rid = osw2_addr
+                tgid = osw1_addr
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DYNAMIC REGROUP src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, tgid, tgid >> 4))
             # Two-OSW Type II affiliation
             elif osw1_cmd == 0x310:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -608,6 +608,11 @@ class osw_receiver(object):
                             tgt_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET RADIO CHECK tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Deaffiliation
+                        elif osw1_addr == 0x261c:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET DEAFFILIATION src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
                         # Unknown extended function
                         else:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1119,7 +1119,7 @@ class osw_receiver(object):
                 type_ii              = (data & 0x1000) >> 12
                 type_str             = "II" if type_ii else "I"
                 dispatch_timeout     = (data & 0xe00) >> 9
-                connect_tone         = (data & 0x1e0) >> 5
+                connect_tone         = (data & 0xe0) >> 5
                 connect_tone_str     = self.get_connect_tone(connect_tone)
                 interconnect_timeout = (data & 0x1f)
                 if self.debug >= 11:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -368,7 +368,7 @@ class osw_receiver(object):
             bp_tx_base_offset = int(from_dict(self.config, 'bp_tx_base_offset', 0))
             if is_tx and (chan >= bp_tx_base_offset) and (chan < 380):
                 return True
-            elif (chan >= bp_base_offset) and (chan < 760):
+            elif not is_tx and (chan >= bp_base_offset) and (chan < 760):
                 return True
             else:
                 return False

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -641,8 +641,9 @@ class osw_receiver(object):
                     self.osw_q.appendleft((osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t))
 
                     if self.debug >= 11:
-                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
-                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
+                        ts = log_ts.get()
+                        sys.stderr.write("%s [%d] SMARTNET OBT UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
+                        sys.stderr.write("%s [%d] SMARTNET OBT UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW group voice grant command
             elif osw1_ch_rx and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
                 mode = 0 if osw2_grp else 1
@@ -662,7 +663,7 @@ class osw_receiver(object):
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))
 
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
+                    sys.stderr.write("%s [%d] SMARTNET OBT UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
         # One-OSW voice update
         elif osw2_ch_rx and osw2_grp:
             dst_tgid = osw2_addr
@@ -860,8 +861,9 @@ class osw_receiver(object):
                     self.osw_q.appendleft((osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t))
 
                     if self.debug >= 11:
-                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
-                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
+                        ts = log_ts.get()
+                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
+                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW date/time
             elif osw1_cmd == 0x322:
                 year   = ((osw2_addr & 0xfe00) >> 9) + 2000

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -744,6 +744,16 @@ class osw_receiver(object):
                     if self.debug >= 11:
                         sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
+            # Two-OSW date/time
+            elif osw1_cmd == 0x322:
+                year = ((osw2_addr & 0xfe00) >> 9) + 2000
+                month = (osw2_addr & 0x1e0) >> 5
+                day = osw2_addr & 0x1f
+                data = (osw1_addr & 0xe000) >> 13
+                hour = (osw1_addr & 0x1f00) >> 8
+                minute = osw1_addr & 0xff
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
             # Two-OSW patch/multiselect
             elif osw1_cmd == 0x340 and (osw2_addr & 0xf == 3 or osw2_addr & 0xf == 7):
                 type_str = "PATCH" if osw2_addr & 0xf == 3 else "MULTISELECT"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -598,9 +598,10 @@ class osw_receiver(object):
         if active:
             feat_str += "active, "
 
+        # Trim the trailing comma and space
         return feat_str[:-2]
 
-    # Convert TGID into a string showing the call options; exclude "CLEAR" prefix if include_clear=False
+    # Convert TGID options into a string showing the call options; exclude "CLEAR" prefix if include_clear=False
     def get_call_options_str(self, tgid, include_clear=True):
         is_encrypted = (tgid & 0x8) >> 3
         options      = (tgid & 0x7)
@@ -628,7 +629,7 @@ class osw_receiver(object):
 
         return options_str
 
-    # Convert mode and TGID into a set of letter flags showing the call options
+    # Convert mode and TGID options into a set of letter flags showing the call options
     def get_call_options_flags_str(self, tgid, mode=None):
         is_encrypted = (tgid & 0x8) >> 3
         options      = (tgid & 0x7)
@@ -651,7 +652,7 @@ class osw_receiver(object):
 
         return options_str
 
-    # Convert mode and TGID into a set of letter flags showing the call options, but for web interface
+    # Convert mode and TGID options into a set of letter flags showing the call options, but for web interface
     def get_call_options_flags_web_str(self, tgid, mode):
         is_encrypted = (tgid & 0x8) >> 3
         options      = (tgid & 0x7)
@@ -663,6 +664,7 @@ class osw_receiver(object):
         options_str += "E" if is_encrypted else "&nbsp;"
         options_str += "&nbsp;"
 
+        # Ensure the string is always length 8, but use non-breaking space, because web
         if options == 0:    options_str += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
         elif options == 1:  options_str += "Ann" + "&nbsp;&nbsp;"
         elif options == 2:  options_str += "Em" + "&nbsp;&nbsp;&nbsp;"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -593,8 +593,10 @@ class osw_receiver(object):
                 sys.stderr.write("%s [%d] SMARTNET RAW OSW (0x%04x,%s,0x%03x;rx:%f,tx:%f)\n" % (log_ts.get(), self.msgq_id, addr, grp_str, cmd, rx_freq, tx_freq))
             elif is_rx_chan:
                 sys.stderr.write("%s [%d] SMARTNET RAW OSW (0x%04x,%s,0x%03x;rx:%f)\n" % (log_ts.get(), self.msgq_id, addr, grp_str, cmd, rx_freq))
-            if is_rx_chan and is_tx_chan:
+            elif is_tx_chan:
                 sys.stderr.write("%s [%d] SMARTNET RAW OSW (0x%04x,%s,0x%03x;tx:%f)\n" % (log_ts.get(), self.msgq_id, addr, grp_str, cmd, tx_freq))
+            else:
+                sys.stderr.write("%s [%d] SMARTNET RAW OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, addr, grp_str, cmd))
 
         self.osw_q.append((addr, (grp != 0), cmd, is_rx_chan, is_tx_chan, rx_freq, tx_freq, ts))
 

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -643,6 +643,20 @@ class osw_receiver(object):
                     if self.debug >= 11:
                         sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
+            # Two-OSW group voice grant command
+            elif osw1_ch_rx and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+                mode = 0 if osw2_grp else 1
+                type_str = "ANALOG" if osw2_grp else "DIGITAL"
+                src_rid = osw2_addr
+                dst_tgid = osw1_addr
+                vc_rx_freq = osw1_f_rx
+                vc_tx_freq = osw2_f_tx
+                rc |= self.update_voice_frequency(vc_rx_freq, dst_tgid, src_rid, mode=mode, ts=osw1_t)
+                if self.debug >= 11:
+                    if vc_tx_freq != 0.0:
+                        sys.stderr.write("%s [%d] SMARTNET OBT %s %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_rx_freq(%f) vc_tx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_rx_freq, vc_tx_freq))
+                    else:
+                        sys.stderr.write("%s [%d] SMARTNET OBT %s %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_rx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_rx_freq))
             else:
                 # Put back unused OSW1
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -641,7 +641,7 @@ class osw_receiver(object):
         options_str += "E " if is_encrypted else "  "
 
         if options != 0:
-            if options == 1:    options_str += "   Ann"
+            if options == 1:    options_str += "Ann"
             elif options == 2:  options_str += "Em"
             elif options == 3:  options_str += "   P"
             elif options == 4:  options_str += "Em P"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -924,9 +924,12 @@ class osw_receiver(object):
             else:
                 # OSW1 did not match, so put it back in the queue
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))
-        # One-OSW system ID
+        # One-OSW system ID / scan marker
         elif osw2_cmd == 0x32b and not osw2_grp:
-            system = osw2_addr
+            system   = osw2_addr
+            type_str = "II"
+            if self.debug >= 11:
+                sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x) type(%s)\n" % (log_ts.get(), self.msgq_id, system, type_str))
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x)\n" % (log_ts.get(), self.msgq_id, system))
         # One-OSW AMSS (Automatic Multiple Site Select) message

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -940,8 +940,6 @@ class osw_receiver(object):
             type_str = "II"
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x) type(%s)\n" % (log_ts.get(), self.msgq_id, system, type_str))
-            if self.debug >= 11:
-                sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x)\n" % (log_ts.get(), self.msgq_id, system))
         # One-OSW AMSS (Automatic Multiple Site Select) message
         elif osw2_cmd >= 0x360 and osw2_cmd <= 0x39f and osw2_grp:
             # Sites are encoded as 0-indexed but usually referred to as 1-indexed

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -32,7 +32,16 @@ from gnuradio import gr
 
 #################
 
-OSW_QUEUE_SIZE          = 5     # Some messages can be 3 OSWs long, plus up to two IDLEs can be inserted in between useful messages
+# Message queue message types (defined in lib/op25_msg_types.h)
+M_SMARTNET_TIMEOUT      = -1
+M_SMARTNET_OSW          =  0
+M_SMARTNET_END_PTT      = 15
+
+# OSW queue values
+OSW_QUEUE_SIZE          = 5     # Some messages can be 3 OSWs long, plus up to two IDLEs can be inserted in between
+                                # useful messages.
+
+# SmartNet trunking constants
 CC_TIMEOUT_RETRIES      = 3     # Number of control channel framing timeouts before hunting
 VC_TIMEOUT_RETRIES      = 3     # Number of voice channel framing timeouts before expiry
 TGID_DEFAULT_PRIO       = 3     # Default tgid priority when unassigned
@@ -303,14 +312,14 @@ class osw_receiver(object):
         m_rxid = int(msg.arg1()) >> 1
         m_ts = float(msg.arg2())
 
-        if (m_type == -1):  # Control Channel Timeout
+        if m_type == M_SMARTNET_TIMEOUT:  # Control Channel Timeout
             if self.debug > 10:
                 sys.stderr.write("%s [%d] control channel timeout\n" % (log_ts.get(), self.msgq_id))
             self.cc_retries += 1
             if self.cc_retries >= CC_TIMEOUT_RETRIES:
                 self.tune_next_cc()
 
-        elif (m_type == 0): # OSW Received
+        elif m_type == M_SMARTNET_OSW: # OSW Received
             s = msg.to_string()
             osw_addr = get_ordinals(s[0:2])
             osw_grp  = get_ordinals(s[2:3])

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -683,8 +683,8 @@ class osw_receiver(object):
             data = osw2_addr
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET IDLE data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
-        # Two-OSW command (0x308 is standard Type II, 0x309 is Type II masqueraded as Type I, whatever that means)
-        elif (osw2_cmd == 0x308) or (osw2_cmd == 0x309):
+        # Two-OSW command
+        elif osw2_cmd == 0x308:
             # Get next OSW in the queue
             osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t = self.osw_q.popleft()
             grp1_str = self.get_group_str(osw1_grp)

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -587,7 +587,7 @@ class osw_receiver(object):
             rx_freq = self.get_freq(cmd)
         if is_tx_chan:
             tx_freq = self.get_freq(cmd, is_tx=True)
-        
+
         if self.debug >= 13:
             if is_rx_chan and is_tx_chan:
                 sys.stderr.write("%s [%d] SMARTNET RAW OSW (0x%04x,%s,0x%03x;rx:%f,tx:%f)\n" % (log_ts.get(), self.msgq_id, addr, grp_str, cmd, rx_freq, tx_freq))
@@ -716,7 +716,7 @@ class osw_receiver(object):
             elif osw1_cmd == 0x30b:
                 # Get next OSW in the queue
                 osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t = self.osw_q.popleft()
-                
+
                 # Three-OSW system ID + control channel broadcast
                 if osw0_ch_rx and (osw0_addr & 0xff00) == 0x1f00 and (osw1_addr & 0xfc00) == 0x2800 and (osw1_addr & 0x3ff) == osw0_cmd:
                     system = osw2_addr
@@ -851,10 +851,10 @@ class osw_receiver(object):
                     # Sites are encoded as 0-indexed but usually referred to as 1-indexed
                     site = ((osw1_addr & 0xfc00) >> 10) + 1
                     band = (osw1_addr & 0x380) >> 7
-                    feat = osw1_addr & 0x3f
+                    feat = (osw1_addr & 0x3f)
                     cc_freq = self.get_freq(osw0_addr & 0x03ff)
                     if self.debug >= 11:
-                        sys.stderr.write("%s [%d] SMARTNET %s sys(0x%04x) site(%02d) band(%s) features(0x%02x) cc_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, sysid, site, self.get_band(band), feat, cc_freq))
+                        sys.stderr.write("%s [%d] SMARTNET %s sys(0x%04x) site(%02d) band(%s) features(%s) cc_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, sysid, site, self.get_band(band), self.get_features_str(feat), cc_freq))
                 else:
                     # Put back unused OSW0
                     self.osw_q.appendleft((osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t))
@@ -864,11 +864,11 @@ class osw_receiver(object):
                         sys.stderr.write("%s [%d] SMARTNET UNKNOWN OSW (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW date/time
             elif osw1_cmd == 0x322:
-                year = ((osw2_addr & 0xfe00) >> 9) + 2000
-                month = (osw2_addr & 0x1e0) >> 5
-                day = osw2_addr & 0x1f
-                data = (osw1_addr & 0xe000) >> 13
-                hour = (osw1_addr & 0x1f00) >> 8
+                year   = ((osw2_addr & 0xfe00) >> 9) + 2000
+                month  = (osw2_addr & 0x1e0) >> 5
+                day    = (osw2_addr & 0x1f)
+                data   = (osw1_addr & 0xe000) >> 13
+                hour   = (osw1_addr & 0x1f00) >> 8
                 minute = osw1_addr & 0xff
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -869,6 +869,12 @@ class osw_receiver(object):
                 rc |= self.update_voice_frequency(osw1_t, vc_freq, dst_tgid, src_rid, mode=0)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET ANALOG %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_freq))
+            # Two-OSW dynamic regroup (unknown whether OSWs are group or individual)
+            elif osw1_cmd == 0x30a:
+                src_rid = osw2_addr
+                tgid = osw1_addr
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DYNAMIC REGROUP src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, tgid, tgid >> 4))
             # One of many possible two- or three-OSW meanings...
             elif osw1_cmd == 0x30b:
                 # Get next OSW in the queue
@@ -1018,12 +1024,6 @@ class osw_receiver(object):
                             code = osw1_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, code))
-            # Two-OSW dynamic regroup (unknown whether OSWs are group or individual)
-            elif osw1_cmd == 0x30a:
-                src_rid = osw2_addr
-                tgid = osw1_addr
-                if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DYNAMIC REGROUP src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, tgid, tgid >> 4))
             # Two-OSW affiliation
             elif osw1_cmd == 0x310 and not osw2_grp and not osw1_grp:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -632,10 +632,10 @@ class osw_receiver(object):
                     cc_rx_freq = self.get_freq(osw0_addr & 0x3ff)
                     cc_tx_freq = osw2_f_tx
                     if self.debug >= 11:
+                        sys.stderr.write("%s [%d] SMARTNET OBT %s sys(0x%04x) site(%02d) band(%s) features(%s) cc_rx_freq(%f)" % (log_ts.get(), self.msgq_id, type_str, sysid, site, self.get_band(band), self.get_features_str(feat), cc_rx_freq))
                         if cc_tx_freq != 0.0:
-                            sys.stderr.write("%s [%d] SMARTNET OBT %s sys(0x%04x) site(%02d) band(%s) features(%s) cc_rx_freq(%f) cc_tx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, sysid, site, self.get_band(band), self.get_features_str(feat), cc_rx_freq, cc_tx_freq))
-                        else:
-                            sys.stderr.write("%s [%d] SMARTNET OBT %s sys(0x%04x) site(%02d) band(%s) features(%s) cc_rx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, sysid, site, self.get_band(band), self.get_features_str(feat), cc_rx_freq))
+                            sys.stderr.write(" cc_tx_freq(%f)" % (cc_tx_freq))
+                        sys.stderr.write("\n")
                 else:
                     # Put back unused OSW0
                     self.osw_q.appendleft((osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t))
@@ -654,10 +654,10 @@ class osw_receiver(object):
                 vc_tx_freq = osw2_f_tx
                 rc |= self.update_voice_frequency(vc_rx_freq, dst_tgid, src_rid, mode=mode, ts=osw1_t)
                 if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET OBT %s %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_rx_freq(%f)" % (log_ts.get(), self.msgq_id, type_str, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_rx_freq))
                     if vc_tx_freq != 0.0:
-                        sys.stderr.write("%s [%d] SMARTNET OBT %s %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_rx_freq(%f) vc_tx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_rx_freq, vc_tx_freq))
-                    else:
-                        sys.stderr.write("%s [%d] SMARTNET OBT %s %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_rx_freq(%f)\n" % (log_ts.get(), self.msgq_id, type_str, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_rx_freq))
+                        sys.stderr.write(" vc_tx_freq(%f)" % (vc_tx_freq))
+                    sys.stderr.write("\n")
             else:
                 # Put back unused OSW1
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -776,7 +776,6 @@ class osw_receiver(object):
                     cc_rx_freq = self.get_freq(cc_rx_chan)
                     cc_tx_freq = osw2_f_tx
                     self.rx_sys_id = system
-                    self.rx_cc_freq = cc_rx_freq * 1e6
                     if osw0_grp:
                         self.add_adjacent_site(osw1_t, site, cc_rx_freq, cc_tx_freq)
                     else:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1201,11 +1201,11 @@ class osw_receiver(object):
                 cvsd_mod_str = "4" if cvsd_mod_4 else "2"
                 trespass     = (data & 0x100) >> 8
                 voc          = (data & 0x80) >> 7
-                bit2_6       = (data & 0x7c) >> 2
+                bit6_2       = (data & 0x7c) >> 2
                 site_trunk   = (data & 0x2) >> 1
                 wide_area    = (data & 0x1)
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit2_6(0x%02x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit2_6))
+                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit6_2(0x%02x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit6_2))
             else:
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS type(%s) opcode(0x%x) data(0x%04x)\n" % (log_ts.get(), self.msgq_id, scope, grp2_str, opcode, data))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -941,12 +941,14 @@ class osw_receiver(object):
             opcode = (osw2_addr & 0xe000) >> 13
             data = osw2_addr & 0x1fff
             if opcode == 1:
-                bit12                = (data & 0x1000) >> 12
+                type_ii              = (data & 0x1000) >> 12
+                type_str             = "II" if type_ii else "I"
                 dispatch_timeout     = (data & 0xe00) >> 9
                 connect_tone         = (data & 0x1e0) >> 5
+                connect_tone_str     = self.get_connect_tone(connect_tone)
                 interconnect_timeout = (data & 0x1f)
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET %s STATUS connect_tone(%.02f) dispatch_timeout(%d) interconnect_timeout(%d) bit12(%d)\n" % (log_ts.get(), self.msgq_id, scope, self.get_connect_tone(connect_tone), dispatch_timeout, interconnect_timeout, bit12))
+                    sys.stderr.write("%s [%d] SMARTNET %s STATUS type(%s) connect_tone(%.02f) dispatch_timeout(%d) interconnect_timeout(%d)\n" % (log_ts.get(), self.msgq_id, scope, type_str, connect_tone_str, dispatch_timeout, interconnect_timeout))
             elif opcode == 2:
                 no_secure        = (data & 0x1000) >> 12
                 secure_upgrade   = (data & 0x800) >> 11

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1019,7 +1019,7 @@ class osw_receiver(object):
 
             # Only show TGID if we believe the call is currently ongoing
             if t - self.voice_frequencies[f]['time'] < 1.0:
-                d['frequencies'][f] = 'voice frequency %f tgid [%5d 0x%03x] %s count %d' %  ((f/1e6), self.voice_frequencies[f]['tgid'], self.voice_frequencies[f]['tgid'] >> 4, time_ago_str, self.voice_frequencies[f]['counter'])
+                d['frequencies'][f] = 'voice frequency %f tgid [%5d 0x%03x]   Now     count %d' %  ((f/1e6), self.voice_frequencies[f]['tgid'], self.voice_frequencies[f]['tgid'] >> 4, time_ago_str, self.voice_frequencies[f]['counter'])
             else:
                 d['frequencies'][f] = 'voice frequency %f tgid [           ] %s count %d' %  ((f/1e6), time_ago_str, self.voice_frequencies[f]['counter'])
 

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -603,11 +603,17 @@ class osw_receiver(object):
                                 sys.stderr.write("%s [%d] SMARTNET GROUP EXTENDED FUNCTION tgid(%05d/0x%03x) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, tgid, tgid >> 4, code))
                     # Extended functions on individuals
                     else:
+                        # Radio check
+                        if osw1_addr == 0x261b:
+                            tgt_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET RADIO CHECK tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
                         # Unknown extended function
-                        src_rid = osw2_addr
-                        code = osw1_addr
-                        if self.debug >= 11:
-                            sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, code))
+                        else:
+                            src_rid = osw2_addr
+                            code = osw1_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, code))
             # Two-OSW Type II affiliation
             elif osw1_cmd == 0x310:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -792,7 +792,7 @@ class osw_receiver(object):
 
                     if self.debug >= 11:
                         ts = log_ts.get()
-                        type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                        type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW group voice grant command
@@ -815,7 +815,7 @@ class osw_receiver(object):
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))
 
                 if self.debug >= 11:
-                    type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                    type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                     sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
         # One-OSW voice update
         elif osw2_ch_rx and osw2_grp:
@@ -1103,7 +1103,7 @@ class osw_receiver(object):
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))
 
                 if self.debug >= 11:
-                    type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                    type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                     sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
         # Two-OSW command
         elif osw2_cmd == 0x321:
@@ -1135,7 +1135,7 @@ class osw_receiver(object):
                 self.osw_q.appendleft((osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t))
 
                 if self.debug >= 11:
-                    type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                    type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                     sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
         # One-OSW system ID / scan marker
         elif osw2_cmd == 0x32b and not osw2_grp:
@@ -1213,7 +1213,7 @@ class osw_receiver(object):
             # Track that we got an unknown OSW
             is_unknown_osw = True
             if self.debug >= 11:
-                type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                 sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
 
         # If we got an unknown OSW after a queue reset, put back the queue reset message so that we know the next

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -797,7 +797,7 @@ class osw_receiver(object):
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET OBT %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW group voice grant command
-            elif osw1_ch_rx and osw2_grp and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+            elif osw1_ch_rx and osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
                 mode = 0 if osw2_grp else 1
                 type_str = "ANALOG" if osw2_grp else "DIGITAL"
                 src_rid = osw2_addr
@@ -1146,12 +1146,14 @@ class osw_receiver(object):
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x) type(%s)\n" % (log_ts.get(), self.msgq_id, system, type_str))
         # One-OSW AMSS (Automatic Multiple Site Select) message
-        elif osw2_cmd >= 0x360 and osw2_cmd <= 0x39f and osw2_grp:
+        elif osw2_cmd >= 0x360 and osw2_cmd <= 0x39f:
             # Sites are encoded as 0-indexed but usually referred to as 1-indexed
             site = osw2_cmd - 0x360 + 1
+            grp_str = grp2_str
+            data = osw2_addr
             self.rx_site_id = site
             if self.debug >= 11:
-                sys.stderr.write("%s [%d] SMARTNET AMSS site(%02d)\n" % (log_ts.get(), self.msgq_id, site))
+                sys.stderr.write("%s [%d] SMARTNET AMSS site(%02d) data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, site, grp_str, data))
         # One-OSW system status update
         elif osw2_cmd == 0x3bf or osw2_cmd == 0x3c0:
             scope = "SYSTEM" if osw2_cmd == 0x3c0 else "NETWORK"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -776,7 +776,7 @@ class osw_receiver(object):
                             type_str = self.get_call_options_str(osw2_addr, include_clear=False)
                             sub_tgid = osw2_addr
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET %s CANCEL sub_tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, sub_tgid, sub_tgid >> 4))
+                                sys.stderr.write("%s [%d] SMARTNET %s CANCEL tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, tgid, tgid >> 4))
                         # Unknown extended function
                         else:
                             tgid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -828,6 +828,12 @@ class osw_receiver(object):
                             tgt_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET RADIO UNINHIBIT tgt(%05d)\n" % (log_ts.get(), self.msgq_id, tgt_rid))
+                        # Denial
+                        elif (osw1_addr & 0xfc00) == 0x2c00:
+                            src_rid = osw2_addr
+                            reason = osw1_addr & 0x3ff
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET DENIED src(%05d) code(0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, reason))
                         # Unknown extended function
                         else:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1019,7 +1019,7 @@ class osw_receiver(object):
 
             # Only show TGID if we believe the call is currently ongoing
             if t - self.voice_frequencies[f]['time'] < 1.0:
-                d['frequencies'][f] = 'voice frequency %f tgid [%5d 0x%03x]   Now     count %d' %  ((f/1e6), self.voice_frequencies[f]['tgid'], self.voice_frequencies[f]['tgid'] >> 4, time_ago_str, self.voice_frequencies[f]['counter'])
+                d['frequencies'][f] = 'voice frequency %f tgid [%5d 0x%03x]   Now     count %d' %  ((f/1e6), self.voice_frequencies[f]['tgid'], self.voice_frequencies[f]['tgid'] >> 4, self.voice_frequencies[f]['counter'])
             else:
                 d['frequencies'][f] = 'voice frequency %f tgid [           ] %s count %d' %  ((f/1e6), time_ago_str, self.voice_frequencies[f]['counter'])
 

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -564,8 +564,14 @@ class osw_receiver(object):
         osw2_addr, osw2_grp, osw2_cmd, osw2_ch, osw2_f, osw2_t = self.osw_q.popleft()
         grp2_str = self.get_group_str(osw2_grp)
 
+        # One-OSW system idle
+        if osw2_cmd == 0x2f8:
+            grp_str = grp2_str
+            data = osw2_addr
+            if self.debug >= 11:
+                sys.stderr.write("%s [%d] SMARTNET IDLE data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
         # Two-OSW command (0x308 is standard Type II, 0x309 is Type II masqueraded as Type I, whatever that means)
-        if (osw2_cmd == 0x308) or (osw2_cmd == 0x309):
+        elif (osw2_cmd == 0x308) or (osw2_cmd == 0x309):
             # Get next OSW in the queue
             osw1_addr, osw1_grp, osw1_cmd, osw1_ch, osw1_f, osw1_t = self.osw_q.popleft()
             grp1_str = self.get_group_str(osw1_grp)

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -750,8 +750,8 @@ class osw_receiver(object):
                     # Extended functions on groups
                     elif osw1_grp:
                         # Patch/multiselect cancel
-                        if osw1_addr == 0x2021 and (osw2_addr & 0xf == 3 or osw2_addr & 0xf == 7):
-                            type_str = "PATCH" if osw2_addr & 0xf == 3 else "MULTISELECT"
+                        if osw1_addr == 0x2021 and (osw2_addr & 0x7 == 3 or osw2_addr & 0x7 == 7):
+                            type_str = "PATCH" if osw2_addr & 0x7 == 3 else "MULTISELECT"
                             sub_tgid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET %s CANCEL sub_tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, sub_tgid, sub_tgid >> 4))
@@ -887,8 +887,8 @@ class osw_receiver(object):
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%1x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
             # Two-OSW patch/multiselect
-            elif osw1_cmd == 0x340 and (osw2_addr & 0xf == 3 or osw2_addr & 0xf == 7):
-                type_str = "PATCH" if osw2_addr & 0xf == 3 else "MULTISELECT"
+            elif osw1_cmd == 0x340 and (osw2_addr & 0x7 == 3 or osw2_addr & 0x7 == 7):
+                type_str = "PATCH" if osw2_addr & 0x7 == 3 else "MULTISELECT"
                 tgid = (osw1_addr & 0xfff) << 4
                 sub_tgid = osw2_addr & 0xfff0
                 if self.debug >= 11:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -883,7 +883,7 @@ class osw_receiver(object):
                 hour   = (osw1_addr & 0x1f00) >> 8
                 minute = osw1_addr & 0xff
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%1x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
+                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%01x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
             # Two-OSW patch/multiselect
             elif osw1_cmd == 0x340 and osw2_grp and osw1_grp and (osw2_addr & 0x7 == 3 or osw2_addr & 0x7 == 7):
                 type_str = "PATCH" if osw2_addr & 0x7 == 3 else "MULTISELECT"
@@ -973,7 +973,7 @@ class osw_receiver(object):
                 site_trunk   = (data & 0x2) >> 1
                 wide_area    = (data & 0x1)
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit2_6(0x%2x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit2_6))
+                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit2_6(0x%02x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit2_6))
             else:
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS type(%s) opcode(0x%x) data(0x%04x)\n" % (log_ts.get(), self.msgq_id, scope, grp2_str, opcode, data))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -652,26 +652,25 @@ class osw_receiver(object):
         return options_str
 
     # Convert mode and TGID into a set of letter flags showing the call options, but for web interface
-    def get_call_options_flags_web_str(self, tgid, mode=None):
+    def get_call_options_flags_web_str(self, tgid, mode):
         is_encrypted = (tgid & 0x8) >> 3
         options      = (tgid & 0x7)
 
-        if mode == None:    options_str = ""
-        elif mode == 0:     options_str = "A"
-        elif mode == 1:     options_str = "D"
-        else:               options_str = "U"
+        if mode == 0:   options_str = "A"
+        elif mode == 1: options_str = "D"
+        else:           options_str = "U"
 
         options_str += "E" if is_encrypted else "&nbsp;"
         options_str += "&nbsp;"
 
-        if options != 0:
-            if options == 1:    options_str += "Ann"
-            elif options == 2:  options_str += "Em"
-            elif options == 3:  options_str += "P"
-            elif options == 4:  options_str += "Em&nbsp;P"
-            elif options == 5:  options_str += "Em&nbsp;MS"
-            elif options == 6:  options_str += "UNDEF"
-            elif options == 7:  options_str += "MS"
+        if options == 0:    options_str += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+        elif options == 1:  options_str += "Ann" + "&nbsp;&nbsp;"
+        elif options == 2:  options_str += "Em" + "&nbsp;&nbsp;&nbsp;"
+        elif options == 3:  options_str += "P" + "&nbsp;&nbsp;&nbsp;&nbsp;"
+        elif options == 4:  options_str += "Em" + "&nbsp;" + "P" + "&nbsp;"
+        elif options == 5:  options_str += "Em" + "&nbsp;" + "MS"
+        elif options == 6:  options_str += "UNDEF"
+        elif options == 7:  options_str += "MS" + "&nbsp;&nbsp;&nbsp;"
 
         return options_str
 

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1155,7 +1155,7 @@ class osw_receiver(object):
             # Only show TGID if we believe the call is currently ongoing
             tgid_dec = "%5d" % (self.voice_frequencies[f]['tgid'])
             tgid_hex = "0x%03x" % (self.voice_frequencies[f]['tgid'] >> 4)
-            if t > self.voice_frequencies[f]['time'] + TGID_EXPIRY_TIME:
+            if t < self.voice_frequencies[f]['time'] + TGID_EXPIRY_TIME:
                 d['frequencies'][f] = 'voice frequency %f tgid [%s %s]   Now     count %d' %  ((f/1e6), tgid_dec, tgid_hex, self.voice_frequencies[f]['counter'])
                 # Co-opt the P25 phase 2 TG slots to show both dec and hex for users who are into that
                 d['frequency_data'][f] = {'tgids': [tgid_hex, tgid_dec], 'last_activity': 'Now', 'counter': self.voice_frequencies[f]['counter']}

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1148,11 +1148,14 @@ class osw_receiver(object):
         elif osw2_cmd >= 0x360 and osw2_cmd <= 0x39f:
             # Sites are encoded as 0-indexed but usually referred to as 1-indexed
             site = osw2_cmd - 0x360 + 1
-            grp_str = grp2_str
-            data = osw2_addr
+            if osw2_grp and (osw2_addr == 0x00000 or osw2_addr == 0xffff):
+                data_str = ""
+            else:
+                # No idea what the data means if it's marked as individual
+                data_str = " data(%s,0x%04x)" % (grp2_str, osw2_addr)
             self.rx_site_id = site
             if self.debug >= 11:
-                sys.stderr.write("%s [%d] SMARTNET AMSS site(%02d) data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, site, grp_str, data))
+                sys.stderr.write("%s [%d] SMARTNET AMSS site(%02d)%s\n" % (log_ts.get(), self.msgq_id, site, data_str))
         # One-OSW system status update
         elif osw2_cmd == 0x3bf or osw2_cmd == 0x3c0:
             scope = "SYSTEM" if osw2_cmd == 0x3c0 else "NETWORK"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -885,7 +885,7 @@ class osw_receiver(object):
                 hour   = (osw1_addr & 0x1f00) >> 8
                 minute = osw1_addr & 0xff
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
+                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%1x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
             # Two-OSW patch/multiselect
             elif osw1_cmd == 0x340 and (osw2_addr & 0xf == 3 or osw2_addr & 0xf == 7):
                 type_str = "PATCH" if osw2_addr & 0xf == 3 else "MULTISELECT"
@@ -963,7 +963,7 @@ class osw_receiver(object):
                         if no_data == 0:
                             sys.stderr.write(" otar(%s)" % (otar_str))
                         sys.stderr.write(" multikey_buf(%s) cvsd_echo_delay(%02d)" % (multikey_buf_str, cvsd_echo_delay))
-                    sys.stderr.write(" bit6(%x) bit0(%x)\n" % (bit6, bit0))
+                    sys.stderr.write(" bit6(%d) bit0(%d)\n" % (bit6, bit0))
             elif opcode == 3:
                 rotation     = (data & 0x800) >> 11
                 wide_pulse   = (data & 0x400) >> 10
@@ -975,7 +975,7 @@ class osw_receiver(object):
                 site_trunk   = (data & 0x2) >> 1
                 wide_area    = (data & 0x1)
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit2_6(%x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit2_6))
+                    sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d) site_trunk(%d) wide_area(%d) bit2_6(0x%2x)\n" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc, site_trunk, wide_area, bit2_6))
             else:
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS type(%s) opcode(0x%x) data(0x%04x)\n" % (log_ts.get(), self.msgq_id, scope, grp2_str, opcode, data))
@@ -1079,7 +1079,7 @@ class osw_receiver(object):
     def to_json(self):  # ugly but required for compatibility with P25 trunking and terminal modules
         d = {}
         d['system']         = self.sysname
-        d['top_line']       = 'SmartNet/SmartZone SysId %04x' % (self.rx_sys_id if self.rx_sys_id is not None else 0)
+        d['top_line']       = 'SmartNet/SmartZone SysId 0x%04x' % (self.rx_sys_id if self.rx_sys_id is not None else 0)
         d['top_line']      += ' Control Ch %f' % ((self.rx_cc_freq if self.rx_cc_freq is not None else self.cc_list[self.cc_index]) / 1e6)
         d['top_line']      += ' OSW count %d' % (self.stats['osw_count'])
         d['secondary']      = ""
@@ -1100,7 +1100,7 @@ class osw_receiver(object):
                 time_ago_str = "%4.1fd ago" % (time_ago / 60.0 / 60.0 / 24.0)
 
             # Only show TGID if we believe the call is currently ongoing
-            if t - self.voice_frequencies[f]['time'] < 1.0:
+            if t - self.voice_frequencies[f]['time'] < TGID_EXPIRY_TIME:
                 d['frequencies'][f] = 'voice frequency %f tgid [%5d 0x%03x]   Now     count %d' %  ((f/1e6), self.voice_frequencies[f]['tgid'], self.voice_frequencies[f]['tgid'] >> 4, self.voice_frequencies[f]['counter'])
             else:
                 d['frequencies'][f] = 'voice frequency %f tgid [           ] %s count %d' %  ((f/1e6), time_ago_str, self.voice_frequencies[f]['counter'])

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -844,6 +844,16 @@ class osw_receiver(object):
             osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t = self.osw_q.popleft()
             grp1_str = self.get_group_str(osw1_grp)
 
+            # One-OSW system idle sometimes ends up in the middle of a multi-OSW command... bit wonky. If that happens,
+            # reorder it (process it first) and then just take the next OSW in the queue.
+            if osw1_cmd == 0x2f8 and not osw1_grp:
+                grp_str = grp1_str
+                data = osw1_addr
+                osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t = self.osw_q.popleft()
+                grp1_str = self.get_group_str(osw1_grp)
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET IDLE REORDERED POSITION 2 data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
+
             # Two-OSW system ID + control channel broadcast
             if osw1_ch_rx and not osw1_grp and ((osw1_addr & 0xff00) == 0x1f00):
                 system = osw2_addr
@@ -865,6 +875,17 @@ class osw_receiver(object):
             elif osw1_cmd == 0x30b:
                 # Get next OSW in the queue
                 osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t = self.osw_q.popleft()
+                grp0_str = self.get_group_str(osw0_grp)
+
+                # One-OSW system idle sometimes ends up in the middle of a multi-OSW command... bit wonky. If that
+                # happens, reorder it (process it first) and then just take the next OSW in the queue.
+                if osw0_cmd == 0x2f8 and not osw0_grp:
+                    grp_str = grp0_str
+                    data = osw0_addr
+                    osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t = self.osw_q.popleft()
+                    grp0_str = self.get_group_str(osw0_grp)
+                    if self.debug >= 11:
+                        sys.stderr.write("%s [%d] SMARTNET IDLE REORDERED POSITION 3 data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
 
                 # Three-OSW system ID + control channel broadcast
                 if (
@@ -1015,6 +1036,17 @@ class osw_receiver(object):
             elif osw1_cmd == 0x320:
                 # Get OSW0
                 osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t = self.osw_q.popleft()
+                grp0_str = self.get_group_str(osw0_grp)
+
+                # One-OSW system idle sometimes ends up in the middle of a multi-OSW command... bit wonky. If that
+                # happens, reorder it (process it first) and then just take the next OSW in the queue.
+                if osw0_cmd == 0x2f8 and not osw0_grp:
+                    grp_str = grp0_str
+                    data = osw0_addr
+                    osw0_addr, osw0_grp, osw0_cmd, osw0_ch_rx, osw0_ch_tx, osw0_f_rx, osw0_f_tx, osw0_t = self.osw_q.popleft()
+                    grp0_str = self.get_group_str(osw0_grp)
+                    if self.debug >= 11:
+                        sys.stderr.write("%s [%d] SMARTNET IDLE REORDERED POSITION 3 data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
 
                 # The information returned here may be for this site, or may be for other adjacent sites
                 if osw0_cmd == 0x30b and osw0_addr & 0xfc00 == 0x6000:
@@ -1042,7 +1074,7 @@ class osw_receiver(object):
 
                     if self.debug >= 11:
                         ts = log_ts.get()
-                        type_str = "UNKNOWN OSW AFTER BAD OSW\n" if is_queue_reset else "UNKNOWN OSW"
+                        type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                         sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
                         sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW date/time
@@ -1079,6 +1111,17 @@ class osw_receiver(object):
         elif osw2_cmd == 0x321:
             # Get next OSW in the queue
             osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t = self.osw_q.popleft()
+            grp1_str = self.get_group_str(osw1_grp)
+
+            # One-OSW system idle sometimes ends up in the middle of a multi-OSW command... bit wonky. If that happens,
+            # reorder it (process it first) and then just take the next OSW in the queue.
+            if osw1_cmd == 0x2f8 and not osw1_grp:
+                grp_str = grp1_str
+                data = osw1_addr
+                osw1_addr, osw1_grp, osw1_cmd, osw1_ch_rx, osw1_ch_tx, osw1_f_rx, osw1_f_tx, osw1_t = self.osw_q.popleft()
+                grp1_str = self.get_group_str(osw1_grp)
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET IDLE REORDERED POSITION 2 data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
 
             # Two-OSW digital group voice grant
             if osw1_ch_rx and osw2_grp and osw1_grp and (osw1_addr != 0):

--- a/op25/gr-op25_repeater/apps/tk_trbo.py
+++ b/op25/gr-op25_repeater/apps/tk_trbo.py
@@ -84,13 +84,14 @@ class dmr_receiver:
 
     def to_json(self):  # ugly but required for compatibility with P25 trunking and terminal modules
         d = {}
+        d['type']           = 'trbo'
         d['system']         = "tk_trbo"
         d['top_line']       = "OP25 TRBO Trunking"
         d['secondary']      = ""
         d['frequencies']    = {}
         d['frequency_data'] = {}
-        d['last_tsbk'] = 0
-        d['adjacent_data'] = ""
+        d['adjacent_data']  = {}
+        d['last_tsbk']      = 0
         return json.dumps(d)
 
     def process_grant(self, m_buf):

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -144,7 +144,7 @@ class trunked_system (object):
                 vc_tgs = "[%5s|%5s]" % (vc1, vc0)
             d['frequencies'][f] = 'voice freq %f, active tgids %s, last seen %4.1fs, count %d' %  (f / 1000000.0, vc_tgs, t - self.voice_frequencies[f]['time'], self.voice_frequencies[f]['counter'])
 
-            d['frequency_data'][f] = {'tgids': self.voice_frequencies[f]['tgid'], 'last_activity': '%7.1f' % (t - self.voice_frequencies[f]['time']), 'counter': self.voice_frequencies[f]['counter']}
+            d['frequency_data'][f] = {'type': 'voice', 'tgids': self.voice_frequencies[f]['tgid'], 'last_activity': '%7.1f' % (t - self.voice_frequencies[f]['time']), 'counter': self.voice_frequencies[f]['counter']}
         d['adjacent_data'] = self.adjacent_data
         return json.dumps(d)
 

--- a/op25/gr-op25_repeater/lib/op25_msg_types.h
+++ b/op25/gr-op25_repeater/lib/op25_msg_types.h
@@ -64,6 +64,7 @@ static const int16_t M_DMR_SLOT_ESB     =  9;
 
 // SMARTNET Messages
 static const int16_t M_SMARTNET_TIMEOUT = -1;
+static const int16_t M_SMARTNET_BAD_OSW = -2;
 static const int16_t M_SMARTNET_OSW     =  0;
 static const int16_t M_SMARTNET_END_PTT = 15;
 

--- a/op25/gr-op25_repeater/lib/rx_smartnet.cc
+++ b/op25/gr-op25_repeater/lib/rx_smartnet.cc
@@ -74,6 +74,7 @@ namespace gr{
                 if (d_debug >= 10) {
                     fprintf(stderr, "%s SMARTNET sync lost\n", logts.get(d_msgq_id));
                 }
+                rx_smartnet::bad_osw();
                 d_in_sync = false;
                 d_rx_count = 0;
                 return;
@@ -91,6 +92,7 @@ namespace gr{
                 if (d_debug >= 10) {
                     fprintf(stderr,"%s SMARTNET crc fail\n", logts.get(d_msgq_id));
                 }
+                rx_smartnet::bad_osw();
                 return;
             }
 

--- a/op25/gr-op25_repeater/lib/rx_smartnet.cc
+++ b/op25/gr-op25_repeater/lib/rx_smartnet.cc
@@ -229,6 +229,21 @@ namespace gr{
             reset_timer();
         }
 
+        void rx_smartnet::bad_osw()
+        {
+            if ((d_msgq_id >= 0) && (!d_msg_queue->full_p())) {
+                std::string m_buf;
+                gr::message::sptr msg;
+                msg = gr::message::make_from_string(m_buf, get_msg_type(PROTOCOL_SMARTNET, M_SMARTNET_BAD_OSW), (d_msgq_id << 1), logts.get_ts());
+                if (!d_msg_queue->full_p())
+                    d_msg_queue->insert_tail(msg);
+            }
+            if (d_debug >= 10) {
+                fprintf(stderr, "%s rx_smartnet::bad_osw:\n", logts.get(d_msgq_id));
+            }
+            reset_timer();
+        }
+
         void rx_smartnet::send_msg(const char* buf) {
             std::string msg_str = std::string(buf,5);
             if ((d_msgq_id >= 0) && (!d_msg_queue->full_p())) {

--- a/op25/gr-op25_repeater/lib/rx_smartnet.h
+++ b/op25/gr-op25_repeater/lib/rx_smartnet.h
@@ -80,6 +80,7 @@ namespace gr{
                 void deinterleave(const uint8_t* buf);
                 void error_correction();
                 bool crc_check();
+                void bad_osw();
                 void send_msg(const char* buf);
 
                 int d_debug;

--- a/op25/gr-op25_repeater/www/www-static/index.html
+++ b/op25/gr-op25_repeater/www/www-static/index.html
@@ -20,8 +20,8 @@
 <li id="li1" class="nav-li"><input id="b1" class="nav-button" type="button" name="B1" value="Home" method="post" action="" onclick="javascript:f_select(&quot;status&quot;);"></li>
 <li id="li2" class="nav-li"><input id="b2" class="nav-button" type="button" name="B2" value="Plot" method="post" action="" onclick="javascript:f_select(&quot;plot&quot;);"></li>
 <li id="li3" class="nav-li"><input id="b3" class="nav-button" type="button" name="B3" value="About" method="post" action="" onclick="javascript:f_select(&quot;about&quot;);"></li>
-<li id="li4"><span class="copyr"> &copy; 2017-2020 Max H. Parke & Graham J. Norbury [boatbod version]</span></li>
-</ul> 
+<li id="li4"><span class="copyr"> &copy; 2017-2024 Max H. Parke & Graham J. Norbury [boatbod version]</span></li>
+</ul>
 </div>
 <div id="div_debug" style="display: none;">
 <br>

--- a/op25/gr-op25_repeater/www/www-static/index.html
+++ b/op25/gr-op25_repeater/www/www-static/index.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-
 	<title>OP25</title>
 	<link rel="stylesheet" type="text/css" href="main.css">
 	<script src="main.js"></script>
@@ -17,41 +16,41 @@
 
 <div class="nav-bar">
 <ul class="nav-ul">
-<li id="li1" class="nav-li"><input id="b1" class="nav-button" type="button" name="B1" value="Home" method="post" action="" onclick="javascript:f_select(&quot;status&quot;);"></li>
-<li id="li2" class="nav-li"><input id="b2" class="nav-button" type="button" name="B2" value="Plot" method="post" action="" onclick="javascript:f_select(&quot;plot&quot;);"></li>
-<li id="li3" class="nav-li"><input id="b3" class="nav-button" type="button" name="B3" value="About" method="post" action="" onclick="javascript:f_select(&quot;about&quot;);"></li>
-<li id="li4"><span class="copyr"> &copy; 2017-2024 Max H. Parke & Graham J. Norbury [boatbod version]</span></li>
+	<li id="li1" class="nav-li"><input id="b1" class="nav-button" type="button" name="B1" value="Home" method="post" action="" onclick="javascript:f_select(&quot;status&quot;);"></li>
+	<li id="li2" class="nav-li"><input id="b2" class="nav-button" type="button" name="B2" value="Plot" method="post" action="" onclick="javascript:f_select(&quot;plot&quot;);"></li>
+	<li id="li3" class="nav-li"><input id="b3" class="nav-button" type="button" name="B3" value="About" method="post" action="" onclick="javascript:f_select(&quot;about&quot;);"></li>
+	<li id="li4"><span class="copyr"> &copy; 2017-2024 Max H. Parke & Graham J. Norbury [boatbod version]</span></li>
 </ul>
 </div>
 <div id="div_debug" style="display: none;">
-<br>
+	<br>
 </div>
 <!-- control buttons -->
 
 <div id="controls1" class="flex-container">
 
 	<div>
-	<input type="button" class="scan-button" name="skip" value="SKIP" title="Skip current tgid" onclick="javascript:f_scan_button(&quot;skip&quot;);">
+		<input type="button" class="scan-button" name="skip" value="SKIP" title="Skip current tgid" onclick="javascript:f_scan_button(&quot;skip&quot;);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="hold" value="HOLD" title="Hold current tgid" onclick="javascript:f_scan_button(&quot;hold&quot;);">
+		<input type="button" class="scan-button" name="hold" value="HOLD" title="Hold current tgid" onclick="javascript:f_scan_button(&quot;hold&quot;);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="goto" value="GOTO" title="Go to tgid" onclick="javascript:f_scan_button(&quot;goto&quot;);">
+		<input type="button" class="scan-button" name="goto" value="GOTO" title="Go to tgid" onclick="javascript:f_scan_button(&quot;goto&quot;);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="lockout" value="B/LIST" title="Blacklist tgid" onclick="javascript:f_scan_button(&quot;lockout&quot;);">
+		<input type="button" class="scan-button" name="lockout" value="B/LIST" title="Blacklist tgid" onclick="javascript:f_scan_button(&quot;lockout&quot;);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="whitelist" value="W/LIST" title="Whitelist tgid" onclick="javascript:f_scan_button(&quot;whitelist&quot;);">
+		<input type="button" class="scan-button" name="whitelist" value="W/LIST" title="Whitelist tgid" onclick="javascript:f_scan_button(&quot;whitelist&quot;);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="log" value="LOG/V" title="Log verbosity" onclick="javascript:f_scan_button(&quot;set_debug&quot;);">
+		<input type="button" class="scan-button" name="log" value="LOG/V" title="Log verbosity" onclick="javascript:f_scan_button(&quot;set_debug&quot;);">
 	</div>
 
 	<div>
@@ -59,19 +58,19 @@
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t1_D" name="<<" value="<<">
+		<input type="button" class="scan-button" id="t1_D" name="<<" value="<<">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t1_d" name="<" value="<">
+		<input type="button" class="scan-button" id="t1_d" name="<" value="<">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t1_u" name=">" value=">">
+		<input type="button" class="scan-button" id="t1_u" name=">" value=">">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t1_U" name=">>" value=">>">
+		<input type="button" class="scan-button" id="t1_U" name=">>" value=">>">
 	</div>
 
 </div>
@@ -79,27 +78,27 @@
 <div id="controls2" class="flex-container" style="display: none;">
 
 	<div>
-	<input type="button" class="scan-button" name="pl1" value="FFT" title="Toggle Spectrum Plot" onclick="javascript:f_plot_button(1);">
+		<input type="button" class="scan-button" name="pl1" value="FFT" title="Toggle Spectrum Plot" onclick="javascript:f_plot_button(1);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="pl2" value="Con" title="Toggle Constellation Plot" onclick="javascript:f_plot_button(2);">
+		<input type="button" class="scan-button" name="pl2" value="Con" title="Toggle Constellation Plot" onclick="javascript:f_plot_button(2);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="pl3" value="Sym" title="Toggle Symbol Plot" onclick="javascript:f_plot_button(3);">
+		<input type="button" class="scan-button" name="pl3" value="Sym" title="Toggle Symbol Plot" onclick="javascript:f_plot_button(3);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="pl4" value="Dat" title="Toggle Datascope Plot" onclick="javascript:f_plot_button(4);">
+		<input type="button" class="scan-button" name="pl4" value="Dat" title="Toggle Datascope Plot" onclick="javascript:f_plot_button(4);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="pl5" value="Mix" title="Toggle Mixer Plot" onclick="javascript:f_plot_button(5);">
+		<input type="button" class="scan-button" name="pl5" value="Mix" title="Toggle Mixer Plot" onclick="javascript:f_plot_button(5);">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" name="pl6" value="Tune" title="Toggle Tuner Plot" onclick="javascript:f_plot_button(6);">
+		<input type="button" class="scan-button" name="pl6" value="Tune" title="Toggle Tuner Plot" onclick="javascript:f_plot_button(6);">
 	</div>
 
 	<div>
@@ -107,19 +106,19 @@
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t2_D" name="<<" value="<<">
+		<input type="button" class="scan-button" id="t2_D" name="<<" value="<<">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t2_d" name="<" value="<">
+		<input type="button" class="scan-button" id="t2_d" name="<" value="<">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t2_u" name=">" value=">">
+		<input type="button" class="scan-button" id="t2_u" name=">" value=">">
 	</div>
 
 	<div>
-	<input type="button" class="scan-button" id="t2_U" name=">>" value=">>">
+		<input type="button" class="scan-button" id="t2_U" name=">>" value=">>">
 	</div>
 
 </div>
@@ -128,15 +127,14 @@
 
 <div id="div_about" style="display:none;">
 	<div class="copyright-text">
-	This program comes with ABSOLUTELY NO WARRANTY.<br>
-	OP25 is free software, and you are welcome to redistribute it<br>
-	under certain conditions.  For further details refer to the "License"
-        link (below).<p>
+		This program comes with ABSOLUTELY NO WARRANTY.<br>
+		OP25 is free software, and you are welcome to redistribute it under certain conditions.<br>
+		For further details refer to the "License" link (below).
+	<p>
 	<table border=0>
 	<tr><td>License:</td><td><a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank">https://www.gnu.org/licenses/gpl-3.0.en.html</a></td></tr>
 	<tr><td>Mailing list:</td><td><a href="https://groups.yahoo.com/neo/groups/op25-dev" target="_blank2">https://groups.yahoo.com/neo/groups/op25-dev</a></td></tr>
-	<tr><td>Download:</td><td><tt>git clone https://git.osmocom.org/op25 &nbsp&nbsp&nbsp[original]
-                                  <br>git clone https://github.com/boatbod/op25 [boatbod fork]</tt></td></tr>
+	<tr><td>Download:</td><td><tt>git clone https://git.osmocom.org/op25 &nbsp&nbsp&nbsp[original]<br>git clone https://github.com/boatbod/op25 [boatbod fork]</tt></td></tr>
 	<tr><td>Web site:</td><td><a href="http://op25.osmocom.org" target="_blank3">http://op25.osmocom.org</a></td></tr>
 	</table>
 	</div>
@@ -149,36 +147,35 @@
 <div id="div_status" style="display: none;">
 
 	<div id="div_s2" class="s2"> <!-- table -->
-            <div class="s2_row">
-	        <div class="s2_cell_a"><span class="label">Frequency:</span></div>
-	        <div class="s2_cell_b1" id="s2_freq">&nbsp</div>
-	        <div class="s2_cell_c" id="s2_ch_lbl" style="display:none;"><span class="label">Channel:</span></div>
-	        <div class="s2_cell_d" id="s2_ch_txt" style="display:none;">&nbsp</div>
-	        <div class="s2_cell_e" id="s2_ch_dn" style="display:none;"><input type="button" class="chan-button" name="c_dn" value="<" title="Prev Channel" onclick="javascript:f_chan_button(-1);"></div>
-	        <div class="s2_cell_f" id="s2_ch_dmp" style="display:none;"><input type="button" class="chan-button" name="c_dmp" value="d" title="Log TGs" onclick="javascript:f_dump_button(0);"></div>
-	        <div class="s2_cell_g" id="s2_ch_up" style="display:none;"><input type="button" class="chan-button" name="c_up>" value=">" title="Next Channel" onclick="javascript:f_chan_button(1);"></div>
-            </div>
-            <div class="s2_row">
-	        <div class="s2_cell_a"><span class="label">Talkgroup:</span></div>
-	        <div class="s2_cell_b2" id="s2_tg">&nbsp</div>
-	        <div class="s2_cell_h" id="s2_ch_cap" style="display:none;"><input type="button" class="cap-button" id="cap_bn" name="c_cap" value="start capture" title="Capture" onclick="javascript:f_cap_button(0);"></div>
-            </div>
-            <div class="s2_row">
-	        <div class="s2_cell_a"><span class="label">Group Addr:</span></div>
-	        <div class="s2_cell_b2" id="s2_grp">&nbsp</div>
-	        <div class="s2_cell_h" id="s2_ch_trk" style="display:none;"><input type="button" class="cap-button" id="trk_bn" name="c_trk" value="tracking" title="Tracking" onclick="javascript:f_trk_button(-1);"></div>
-            </div>
-            <div class="s2_row">
-	        <div class="s2_cell_a"><span class="label">Source Addr:</span></div>
-	        <div class="s2_cell_b" id="s2_src">&nbsp</div>
-            </div>
+		<div class="s2_row">
+			<div class="s2_cell_a"><span class="label">Frequency:</span></div>
+			<div class="s2_cell_b1" id="s2_freq">&nbsp</div>
+			<div class="s2_cell_c" id="s2_ch_lbl" style="display:none;"><span class="label">Channel:</span></div>
+			<div class="s2_cell_d" id="s2_ch_txt" style="display:none;">&nbsp</div>
+			<div class="s2_cell_e" id="s2_ch_dn" style="display:none;"><input type="button" class="chan-button" name="c_dn" value="<" title="Prev Channel" onclick="javascript:f_chan_button(-1);"></div>
+			<div class="s2_cell_f" id="s2_ch_dmp" style="display:none;"><input type="button" class="chan-button" name="c_dmp" value="d" title="Log TGs" onclick="javascript:f_dump_button(0);"></div>
+			<div class="s2_cell_g" id="s2_ch_up" style="display:none;"><input type="button" class="chan-button" name="c_up>" value=">" title="Next Channel" onclick="javascript:f_chan_button(1);"></div>
+		</div>
+		<div class="s2_row">
+			<div class="s2_cell_a"><span class="label">Talkgroup:</span></div>
+			<div class="s2_cell_b2" id="s2_tg">&nbsp</div>
+			<div class="s2_cell_h" id="s2_ch_cap" style="display:none;"><input type="button" class="cap-button" id="cap_bn" name="c_cap" value="start capture" title="Capture" onclick="javascript:f_cap_button(0);"></div>
+		</div>
+		<div class="s2_row">
+			<div class="s2_cell_a"><span class="label">Group Addr:</span></div>
+			<div class="s2_cell_b2" id="s2_grp">&nbsp</div>
+			<div class="s2_cell_h" id="s2_ch_trk" style="display:none;"><input type="button" class="cap-button" id="trk_bn" name="c_trk" value="tracking" title="Tracking" onclick="javascript:f_trk_button(-1);"></div>
+		</div>
+		<div class="s2_row">
+			<div class="s2_cell_a"><span class="label">Source Addr:</span></div>
+			<div class="s2_cell_b" id="s2_src">&nbsp</div>
+		</div>
 	</div> <!-- end table -->
 
 	<br>
 
 	<div id="div_s1" class="s1">
 	<!-- system freq -->
-
 		Waiting for data...
 	</div>
 	<br>

--- a/op25/gr-op25_repeater/www/www-static/main.css
+++ b/op25/gr-op25_repeater/www/www-static/main.css
@@ -5,10 +5,10 @@
 
 }
 
-#div_status table { 
+#div_status table {
 
-	border-style: solid; 
-	background-color: #336699; 
+	border-style: solid;
+	background-color: #336699;
 	border-collapse: collapse;
 	font-family: "Courier New", Courier, Monospace;
 
@@ -34,9 +34,9 @@
 }
 
 hr {
-	width:   730px;
+	width: 730px;
 	float: left;
-        padding: 0px;
+	padding: 0px;
 }
 
 /* the buttons */
@@ -109,23 +109,23 @@ hr {
 /* flex container for top buttons */
 
 /*
-the flex properties are more useful when a variable-width is applied, 
+the flex properties are more useful when a variable-width is applied,
 but can be safely left in place even when using a fixed width
 */
 
 .flex-container {
-  display: flex;
-  width: 730px;
-  justify-content: space-between;
+	display: flex;
+	width: 730px;
+	justify-content: space-between;
 
 }
 
 .flex-container > div {
-  width: 100px;
-  margin: 0px;
-  text-align: center;
-  line-height: 75px;
-  font-size: 30px;
+	width: 100px;
+	margin: 0px;
+	text-align: center;
+	line-height: 75px;
+	font-size: 30px;
 }
 
 
@@ -176,7 +176,7 @@ div.right_column {
 
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 14px;
-        padding: 20px;
+	padding: 20px;
 	color: #484848;
 	float: right;
 }

--- a/op25/gr-op25_repeater/www/www-static/main.css
+++ b/op25/gr-op25_repeater/www/www-static/main.css
@@ -153,7 +153,7 @@ div.system {
 	position: absolute;
 	top: 10px;
 	left: 0;
-	width: 54%;
+	width: 60%;
 	height: auto;
 	border: 0px solid #d00
 }
@@ -164,7 +164,7 @@ div.right_column {
 
 	position: relative;
 	top: 10px;
-	width: 42%;
+	width: 36%;
 	float: right;
 	height: auto;
 	border: 0px solid #00f;

--- a/op25/gr-op25_repeater/www/www-static/main.css
+++ b/op25/gr-op25_repeater/www/www-static/main.css
@@ -34,7 +34,7 @@
 }
 
 hr {
-	width: 730px;
+	width: 830px;
 	float: left;
 	padding: 0px;
 }
@@ -115,7 +115,7 @@ but can be safely left in place even when using a fixed width
 
 .flex-container {
 	display: flex;
-	width: 730px;
+	width: 830px;
 	justify-content: space-between;
 
 }
@@ -134,7 +134,7 @@ but can be safely left in place even when using a fixed width
 div.info {
 
 	position: relative;
-	width: 730px;
+	width: 830px;
 	height: auto;
 	border: 0px solid #000;
 }
@@ -224,7 +224,7 @@ div.right_column {
 	border: 1px solid #999;
 	height: auto;
 	overflow: auto;
-	width: 720px;
+	width: 820px;
 	padding: 5px;
 	background: LightGray; /* For browsers that do not support gradients */
 	background: linear-gradient(White, Silver);
@@ -330,7 +330,7 @@ div.right_column {
 }
 
 .nav-bar {
-	width: 730px;
+	width: 830px;
 	padding: 0;
 	border: 1px solid #000;
 }

--- a/op25/gr-op25_repeater/www/www-static/main.css
+++ b/op25/gr-op25_repeater/www/www-static/main.css
@@ -158,9 +158,9 @@ div.system {
 	border: 0px solid #d00
 }
 
-/* adjacent sites container that holds the table */
+/* right column container that holds the adjacent sites and patch tables */
 
-div.adjacent {
+div.right_column {
 
 	position: relative;
 	top: 10px;

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -641,7 +641,7 @@ function trunk_update(d) {
             }
             else {
                 if (tg1 != null || tg2 != null)
-                    mode_str = "<td>" + mode + "</td>"
+                    mode_str = "<td style=\"text-align:center;\">" + mode + "</td>"
                 if (tg1 == null)
                     tg1 = "&nbsp&nbsp-&nbsp&nbsp";
                 if (tg2 == null)

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -560,6 +560,8 @@ function trunk_update(d) {
         html += "</span><br>";
 
         var is_p25 = d[nac]['type'] == "p25"
+        var is_smartnet = d[nac]['type'] == "smartnet"
+
         if (d[nac]['rfid'] != undefined)
             html += "<span class=\"label\">RFSS ID: </span><span class=\"value\">" + d[nac]['rfid'] + " </span>";
         if (d[nac]['stid'] != undefined)
@@ -597,33 +599,72 @@ function trunk_update(d) {
         html += "<div class=\"info\"><div class=\"system\">";
         html += "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>"; // was width=350
         html += "<colgroup>";
-        html += "<col span=\"1\" style=\"width:25%;\">";
-        html += "<col span=\"1\" style=\"width:15%;\">";
-        html += "<col span=\"1\" style=\"width:24%;\">";
-        html += "<col span=\"1\" style=\"width:24%;\">";
-        html += "<col span=\"1\" style=\"width:12%;\">";
+        if (is_smartnet) {
+            html += "<col span=\"1\" style=\"width:20%;\">";
+            html += "<col span=\"1\" style=\"width:11%;\">";
+            html += "<col span=\"1\" style=\"width:20%;\">";
+            html += "<col span=\"1\" style=\"width:20%;\">";
+            html += "<col span=\"1\" style=\"width:18%;\">";
+            html += "<col span=\"1\" style=\"width:11%;\">";
+        }
+        else {
+            html += "<col span=\"1\" style=\"width:25%;\">";
+            html += "<col span=\"1\" style=\"width:15%;\">";
+            html += "<col span=\"1\" style=\"width:24%;\">";
+            html += "<col span=\"1\" style=\"width:24%;\">";
+            html += "<col span=\"1\" style=\"width:12%;\">";
+        }
         html += "</colgroup>";
         html += "<tr><th colspan=99 style=\"align: center\">System Frequencies</th></tr>";
-        html += "<tr><th>Voice Frequency</th><th>Last Used</th><th colspan=2>Active Talkgoup&nbspId</th><th>Count</th></tr>";
+        html += "<tr><th>Frequency</th><th>Last Used</th><th colspan=2>Active Talkgoup&nbspID</th>";
+        if (is_smartnet)
+            html += "<th>Mode</th>";
+        html += "<th>Voice Count</th></tr>";
         var ct = 0;
         for (var freq in d[nac]['frequency_data']) {
+            chan_type = d[nac]['frequency_data'][freq]['type'];
+            last_activity = d[nac]['frequency_data'][freq]['last_activity'];
             tg1 = d[nac]['frequency_data'][freq]['tgids'][0];
             tg2 = d[nac]['frequency_data'][freq]['tgids'][1];
-            if (tg1 == null)
-                tg1 = "&nbsp&nbsp-&nbsp&nbsp";
-            if (tg2 == null)
-                tg2 = "&nbsp&nbsp-&nbsp&nbsp";
-            if (tg1 == tg2) {
-                tg_str = "<td style=\"text-align:center;\" colspan=2>" + tg1 + "</td>";
+            mode = d[nac]['frequency_data'][freq]['mode'];
+            count = d[nac]['frequency_data'][freq]['counter'];
+            // Do alternate first because active TGs will deliberately overwrite the mode
+            if (chan_type == 'alternate')
+                mode_str = "<td style=\"text-align:center;\">Alt</td>"
+            else
+                mode_str = "<td></td>"
+            // Now actually handle the appropriate channel type if not alternate
+            if (chan_type == 'control') {
+                tg_str = "<td style=\"text-align:center;\" colspan=2>Control</td>";
+                mode_str = "<td style=\"text-align:center;\">CC</td>"
+                count = "";
             }
             else {
-                tg_str = "<td style=\"text-align:center;\">" + tg2 + "</td><td style=\"text-align:center;\">" + tg1 + "</td>";
+                if (tg1 != null || tg2 != null)
+                    mode_str = "<td>" + mode + "</td>"
+                if (tg1 == null)
+                    tg1 = "&nbsp&nbsp-&nbsp&nbsp";
+                if (tg2 == null)
+                    tg2 = "&nbsp&nbsp-&nbsp&nbsp";
+                if (tg1 == tg2) {
+                    tg_str = "<td style=\"text-align:center;\" colspan=2>" + tg1 + "</td>";
+                }
+                else {
+                    tg_str = "<td style=\"text-align:center;\">" + tg2 + "</td><td style=\"text-align:center;\">" + tg1 + "</td>";
+                }
             }
             var color = "#d0d0d0";
             if ((ct & 1) == 0)
                 color = "#c0c0c0";
             ct += 1;
-            html += "<tr style=\"background-color: " + color + ";\"><td>" + (parseInt(freq) / 1000000.0).toFixed(6) + "</td><td style=\"text-align:right;\">" + d[nac]['frequency_data'][freq]['last_activity'] + "</td>" + tg_str + "<td style=\"text-align:right;\">" + d[nac]['frequency_data'][freq]['counter'] + "</td></tr>";
+            html += "<tr style=\"background-color: " + color + ";\">";
+            html += "<td>" + (parseInt(freq) / 1000000.0).toFixed(6) + "</td>";
+            html += "<td style=\"text-align:right;\">" + last_activity + "</td>";
+            html += tg_str;
+            if (is_smartnet)
+                html += mode_str;
+            html += "<td style=\"text-align:right;\">" + count + "</td>";
+            html += "</tr>";
         }
         html += "</table></div>";
 

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -559,15 +559,22 @@ function trunk_update(d) {
         html += d[nac]['top_line'];
         html += "</span><br>";
 
+        var is_p25 = d[nac]['type'] == "p25"
         if (d[nac]['rfid'] != undefined)
             html += "<span class=\"label\">RFSS ID: </span><span class=\"value\">" + d[nac]['rfid'] + " </span>";
         if (d[nac]['stid'] != undefined)
             html += "<span class=\"label\">Site ID: </span><span class=\"value\">" + d[nac]['stid'] + "</span><br>";
         if (d[nac]['secondary'] != undefined && d[nac]["secondary"].length) {
-            html += "<span class=\"label\">Secondary control channel(s): </span><span class=\"value\"> ";
+            html += "<span class=\"label\">";
+            if (is_p25)
+                html += "Secondary";
+            else
+                html += "Alternate";
+            html += " control channel(s): </span><span class=\"value\"> ";
             for (i=0; i<d[nac]["secondary"].length; i++) {
+                if (i != 0)
+                    html += ", ";
                 html += (d[nac]["secondary"][i] / 1000000.0).toFixed(6);
-                html += " ";
             }
             html += "</span><br>";
         }

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -636,7 +636,9 @@ function trunk_update(d) {
             // Now actually handle the appropriate channel type if not alternate
             if (chan_type == 'control') {
                 tg_str = "<td style=\"text-align:center;\" colspan=2>Control</td>";
-                mode_str = "<td style=\"text-align:center;\">CC</td>"
+                // Deliberately 8 characters wide, to ensure the column stays the right width without flickering when
+                // call status flags come and go with calls
+                mode_str = "<td style=\"text-align:center;\">&nbsp;&nbsp;&nbsp;CC&nbsp;&nbsp;&nbsp;</td>"
                 count = "";
             }
             else {

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -427,21 +427,28 @@ function channel_status() {
 // adjacent sites table
 
 function adjacent_data(d) {
-    if (Object.keys(d).length < 1) {
+    if (d['adjacent_data'] != null && Object.keys(d['adjacent_data']).length < 1) {
         var html = "</div>";
         return html;
     }
+    var is_p25 = (d['type'] == "p25");
     var html = "<div class=\"adjacent\">";
     html += "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>";
     html += "<tr><th colspan=99 style=\"align: center\">Adjacent Sites</th></tr>";
-    html += "<tr><th>Frequency</th><th>RFSS</th><th>Site</th><th>Uplink</th></tr>";
+    html += "<tr><th>Frequency</th>";
+    if (is_p25) // Only P25 has RFSS
+        html += "<th>RFSS</th>";
+    html += "<th>Site</th><th>Uplink</th></tr>";
     var ct = 0;
-    for (var freq in d) {
+    for (var freq in d['adjacent_data']) {
         var color = "#d0d0d0";
         if ((ct & 1) == 0)
             color = "#c0c0c0";
         ct += 1;
-        html += "<tr style=\"background-color: " + color + ";\"><td>" + (freq / 1000000.0).toFixed(6) + "</td><td>" + d[freq]["rfid"] + "</td><td>" + d[freq]["stid"] + "</td><td>" + (d[freq]["uplink"] / 1000000.0).toFixed(6) + "</td></tr>";
+        html += "<tr style=\"background-color: " + color + ";\"><td>" + (freq / 1000000.0).toFixed(6) + "</td>";
+        if (is_p25)
+            html += "<td>" + d['adjacent_data'][freq]["rfid"] + "</td>";
+        html += "<td>" + d['adjacent_data'][freq]["stid"] + "</td><td>" + (d['adjacent_data'][freq]["uplink"] / 1000000.0).toFixed(6) + "</td></tr>";
     }
     html += "</table></div></div><br><br>";
 
@@ -549,7 +556,7 @@ function trunk_update(d) {
 
 // end system freqencies table
 
-        html += adjacent_data(d[nac]['adjacent_data']);
+        html += adjacent_data(d[nac]);
     }
 
     if (d['srcaddr'] != undefined)

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -469,7 +469,7 @@ function patches(d) {
 
 // adjacent sites table
 
-function adjacent_data(d) {
+function adjacent_sites(d) {
     if (d['adjacent_data'] == undefined || Object.keys(d['adjacent_data']).length < 1) {
         return "";
     }
@@ -599,7 +599,7 @@ function trunk_update(d) {
 
         html += "<div class=\"right_column\">";
         html += patches(d[nac]);
-        html += adjacent_data(d[nac]);
+        html += adjacent_sites(d[nac]);
         html += "</div></div></div>";
     }
 

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -424,16 +424,57 @@ function channel_status() {
         s2_trk.value = "tracking on";
 }
 
+// patches table
+
+function patches(d) {
+    if (d['patch_data'] == undefined || Object.keys(d['patch_data']).length < 1) {
+        return "";
+    }
+
+    // Only support Type II to start
+    if (d['type'] != "smartnet") {
+        return ""
+    }
+
+    var html = "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>";
+    html += "<tr><th colspan=99 style=\"align: center\">Patches</th></tr>";
+    html += "<tr><th colspan=2>TG</th><th colspan=2>Sub TG</th><th>Mode</th></tr>";
+    var ct = 0;
+    for (var tgid in d['patch_data']) {
+        var color = "#d0d0d0";
+        if ((ct & 1) == 0)
+            color = "#c0c0c0";
+        ct += 1;
+
+        num_sub_tgids = Object.keys(d['patch_data'][tgid]).length
+        var index = 0;
+        for (var sub_tgid in d['patch_data'][tgid]) {
+            if (++index == 1) {
+                html += "<tr style=\"background-color: " + color + ";\">";
+                html += "<td rowspan=" + num_sub_tgids + ">" + d['patch_data'][tgid][sub_tgid]['tgid_dec'] + "</td><td rowspan=" + num_sub_tgids + ">" + d['patch_data'][tgid][sub_tgid]['tgid_hex'] + "</td>";
+            } else {
+                html += "<tr style=\"background-color: " + color + ";\">";
+            }
+            html += "<td>" + d['patch_data'][tgid][sub_tgid]['sub_tgid_dec'] + "</td><td>" + d['patch_data'][tgid][sub_tgid]['sub_tgid_hex'] + "</td>";
+            html += "<td>" + d['patch_data'][tgid][sub_tgid]['mode'] + "</td>";
+            html += "</tr>";
+        }
+    }
+    html += "</table><br>";
+
+// end patch table
+
+    return html;
+}
+
 // adjacent sites table
 
 function adjacent_data(d) {
-    if (d['adjacent_data'] != null && Object.keys(d['adjacent_data']).length < 1) {
-        var html = "</div>";
-        return html;
+    if (d['adjacent_data'] == undefined || Object.keys(d['adjacent_data']).length < 1) {
+        return "";
     }
     var is_p25 = (d['type'] == "p25");
-    var html = "<div class=\"adjacent\">";
-    html += "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>";
+    var html = "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>";
     html += "<tr><th colspan=99 style=\"align: center\">Adjacent Sites</th></tr>";
     html += "<tr><th>Frequency</th>";
     if (is_p25) // Only P25 has RFSS
@@ -450,7 +491,7 @@ function adjacent_data(d) {
             html += "<td>" + d['adjacent_data'][freq]["rfid"] + "</td>";
         html += "<td>" + d['adjacent_data'][freq]["stid"] + "</td><td>" + (d['adjacent_data'][freq]["uplink"] / 1000000.0).toFixed(6) + "</td></tr>";
     }
-    html += "</table></div></div><br><br>";
+    html += "</table><br>";
 
 // end adjacent sites table
 
@@ -556,7 +597,10 @@ function trunk_update(d) {
 
 // end system freqencies table
 
+        html += "<div class=\"right_column\">";
+        html += patches(d[nac]);
         html += adjacent_data(d[nac]);
+        html += "</div></div></div>";
     }
 
     if (d['srcaddr'] != undefined)

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -447,9 +447,9 @@ function patches(d) {
         ct += 1;
 
         num_sub_tgids = Object.keys(d['patch_data'][tgid]).length
-        var index = 0;
+        var row_num = 0;
         for (var sub_tgid in d['patch_data'][tgid]) {
-            if (++index == 1) {
+            if (++row_num == 1) {
                 html += "<tr style=\"background-color: " + color + ";\">";
                 html += "<td rowspan=" + num_sub_tgids + ">" + d['patch_data'][tgid][sub_tgid]['tgid_dec'] + "</td><td rowspan=" + num_sub_tgids + ">" + d['patch_data'][tgid][sub_tgid]['tgid_hex'] + "</td>";
             } else {
@@ -476,20 +476,45 @@ function adjacent_sites(d) {
     var is_p25 = (d['type'] == "p25");
     var html = "<table border=1 borderwidth=0 cellpadding=0 cellspacing=0 width=100%>";
     html += "<tr><th colspan=99 style=\"align: center\">Adjacent Sites</th></tr>";
-    html += "<tr><th>Frequency</th>";
-    if (is_p25) // Only P25 has RFSS
-        html += "<th>RFSS</th>";
-    html += "<th>Site</th><th>Uplink</th></tr>";
-    var ct = 0;
-    for (var freq in d['adjacent_data']) {
-        var color = "#d0d0d0";
-        if ((ct & 1) == 0)
-            color = "#c0c0c0";
-        ct += 1;
-        html += "<tr style=\"background-color: " + color + ";\"><td>" + (freq / 1000000.0).toFixed(6) + "</td>";
-        if (is_p25)
-            html += "<td>" + d['adjacent_data'][freq]["rfid"] + "</td>";
-        html += "<td>" + d['adjacent_data'][freq]["stid"] + "</td><td>" + (d['adjacent_data'][freq]["uplink"] / 1000000.0).toFixed(6) + "</td></tr>";
+    if (d['type'] == "p25") {
+        html += "<tr><th>RFSS</th><th>Site</th><th>Frequency</th><th>Uplink</th></tr>";
+        var ct = 0;
+        // Ordered by RFSS then site number
+        for (var freq in d['adjacent_data']) {
+            var rfss = d['adjacent_data'][freq]["rfid"];
+            var site = d['adjacent_data'][freq]["stid"];
+            adjacent_by_rfss[rfss] = {};
+            adjacent_by_rfss[rfss][site] = {};
+            adjacent_by_rfss[rfss][site]['cc_rx_freq'] = (freq / 1000000.0).toFixed(6);
+            adjacent_by_rfss[rfss][site]['cc_tx_freq'] = (d['adjacent_data'][freq]["uplink"] / 1000000.0).toFixed(6);
+        }
+        for (var rfss in adjacent_by_rfss) {
+            for (var site in adjacent_by_rfss[rfss]) {
+                var color = "#d0d0d0";
+                if ((ct & 1) == 0)
+                    color = "#c0c0c0";
+                ct += 1;
+                html += "<tr style=\"background-color: " + color + ";\"><td>" + rfss + "</td><td>" + site + "</td><td>" + adjacent_by_rfss[rfss][site]["cc_rx_freq"] + "</td><td>" + adjacent_by_rfss[rfss][site]["cc_tx_freq"] + "</td></tr>";
+            }
+        }
+    } else if (d['type'] == "smartnet") {
+        html += "<tr><th>Site</th><th>Frequency</th><th>Uplink</th></tr>";
+        var ct = 0;
+        // Ordered by site number
+        var adjacent_by_site = {};
+        for (var freq in d['adjacent_data']) {
+            var site = d['adjacent_data'][freq]["stid"];
+            adjacent_by_site[site] = {};
+            adjacent_by_site[site]['cc_rx_freq'] = (freq / 1000000.0).toFixed(6);
+            adjacent_by_site[site]['cc_tx_freq'] = (d['adjacent_data'][freq]["uplink"] / 1000000.0).toFixed(6);
+        }
+        for (var site in adjacent_by_site) {
+            var color = "#d0d0d0";
+            if ((ct & 1) == 0)
+                color = "#c0c0c0";
+            ct += 1;
+            html += "<tr style=\"background-color: " + color + ";\"><td>" + site + "</td><td>" + adjacent_by_site[site]["cc_rx_freq"] + "</td><td>" + adjacent_by_site[site]["cc_tx_freq"] + "</td></tr>";
+        }
     }
     html += "</table><br>";
 

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -1,19 +1,19 @@
 
 // Copyright 2017, 2018 Max H. Parke KA1RBI
 // Copyright 2018, 2019, 2020, 2021 gnorbury@bondcar.com
-// 
+//
 // This file is part of OP25
-// 
+//
 // OP25 is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 3, or (at your option)
 // any later version.
-// 
+//
 // OP25 is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
 // License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with OP25; see the file COPYING. If not, write to the Free
 // Software Foundation, Inc., 51 Franklin Street, Boston, MA
@@ -271,7 +271,7 @@ function channel_update(d) {
     var s2_ht = document.getElementById("s2_ch_trk");
 
     if (d['channels'] != undefined) {
-        channel_list = d['channels'];    
+        channel_list = d['channels'];
 
         if (channel_list.length > 0) {
             // if this is the first update, find the default_channel if specified
@@ -406,7 +406,7 @@ function channel_status() {
     s2_grp.innerHTML = html;
 
     html = "";
-    if ((c_srcaddr != 0) && (c_srcaddr != 0xffffff)) 
+    if ((c_srcaddr != 0) && (c_srcaddr != 0xffffff))
         if (c_srctag != "")
             html += "<span class=\"value\">" + c_srctag + "</span>";
         else


### PR DESCRIPTION
Per request, I waited until I had substantial changes that were tested - sorry it's so big.

This first PR includes work done using OTA messages as well as confirmed messages RE-ed from other sources.

## Add more OSWs

This PR adds many new OSWs, including support for voice call grants, OBT call grants including explicit tx frequencies, various extended function messages, denials, dynamic regrouping, date/time, patches/multiselects, AMSS, and various system/network status messages.

Note that future changes will add more OSWs after they have been confirmed.

## Improve parsing reliability

### Bad OSW queue reset

This PR adds logic to track when a `sync lost` or `crc fail` event occurs in `rx_smartnet.cc` and uses that to reset the OSW queue in `tk_smartnet.py`. In addition to the reset, it properly handles parsing messages after a queue reset, fixing the issue of bad OSWs being transparent to Python and parsing skipping over them.

### System IDLE command reordering

We also add a lot of wonky logic to handle system `IDLE` commands, which are sometimes injected in the middle of other multi-OSW messages.

## Improve display

### Display call options

This PR displays call options (analog/digital, emergency, patch, etc) on both the `ncurses` and web terminal interfaces.

### Track alternate CCs

This PR adds alternate CC tracking and displays them inline with the system frequencies on both the `ncurses` and web terminal interfaces.

### Track adjacent sites

This PR adds adjacent site tracking and display on the web terminal interface.

### Track patches

This PR adds patch tracking and display on the web terminal interface.
