### PR TITLE
P25: Log encryption info with leading zeroes

### DIFF
--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -917,7 +917,7 @@ class p25_system(object):
         sa    = get_ordinals(msg[12:15])
         ga    = get_ordinals(msg[15:17])
         if self.debug >= 10:
-            sys.stderr.write('%s [%d] mac_ptt: mi: %x algid: %x keyid:%x ga: %d sa: %d\n' % (log_ts.get(), m_rxid, mi, algid, keyid, ga, sa))
+            sys.stderr.write('%s [%d] mac_ptt: mi: %018x algid: %02x keyid: %04x ga: %d sa: %d\n' % (log_ts.get(), m_rxid, mi, algid, keyid, ga, sa))
         return self.update_talkgroup_srcaddr(curr_time, ga, sa)
 
     def decode_tdma_endptt(self, m_rxid, msg, curr_time):
@@ -1802,7 +1802,7 @@ class p25_receiver(object):
                 sa    = get_ordinals(s[12:15])
                 ga    = get_ordinals(s[15:17])
                 if self.debug >= 10:
-                    sys.stderr.write('%s [%d] mac_ptt: mi: %x algid: %x keyid:%x ga: %d sa: %d\n' % (log_ts.get(), m_rxid, mi, algid, keyid, ga, sa))
+                    sys.stderr.write('%s [%d] mac_ptt: mi: %018x algid: %02x keyid: %04x ga: %d sa: %d\n' % (log_ts.get(), m_rxid, mi, algid, keyid, ga, sa))
                 updated += self.system.update_talkgroup_srcaddr(curr_time, ga, sa)
                 if algid != 0x80: # log and save encryption information
                     if self.debug >= 5 and (algid != self.talkgroups[ga]['algid'] or keyid != self.talkgroups[ga]['keyid']):

--- a/op25/gr-op25_repeater/apps/trunking.py
+++ b/op25/gr-op25_repeater/apps/trunking.py
@@ -819,7 +819,7 @@ class trunked_system (object):
         sa    = get_ordinals(msg[12:15])
         ga    = get_ordinals(msg[15:17])
         if self.debug >= 10:
-            sys.stderr.write('%s [0] mac_ptt: mi: %x algid: %x keyid:%x ga: %d sa: %d\n' % (log_ts.get(), mi, algid, keyid, ga, sa))
+            sys.stderr.write('%s [0] mac_ptt: mi: %018x algid: %02x keyid: %04x ga: %d sa: %d\n' % (log_ts.get(), mi, algid, keyid, ga, sa))
         updated += self.update_talkgroup_srcaddr(curr_time, ga, sa)
         updated += self.update_talkgroup_encrypted(curr_time, ga, (algid != 0x80))
         self.rxctl.current_encrypted = (algid != 0x80)


### PR DESCRIPTION
Logging the MI in particular (but also algID and keyID) without leading zeroes can be very confusing - it's a long number, so it's hard to tell if it's off by one digit. However using a value that's off by a digit results in a wrong keystream.