### PR TITLE
SmartNet: add more OSWs verified by IntelliRepeater and sniffed OTA

### DIFF
--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1495,6 +1495,11 @@ class osw_receiver(object):
             self.rx_sys_id = system
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET SYSTEM sys(0x%04x) type(%s)\n" % (log_ts.get(), self.msgq_id, system, type_str))
+        # One-OSW roaming
+        elif osw2_cmd == 0x32c and not osw2_grp:
+            src_rid = osw2_addr
+            if self.debug >= 11:
+                sys.stderr.write("%s [%d] SMARTNET ROAMING src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
         # One-OSW AMSS (Automatic Multiple Site Select) message
         elif osw2_cmd >= 0x360 and osw2_cmd <= 0x39f:
             # Sites are encoded as 0-indexed but usually referred to as 1-indexed

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -904,13 +904,13 @@ class osw_receiver(object):
                 rc |= self.update_voice_frequency(osw1_t, vc_freq, dst_tgid, src_rid, mode=0)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET ANALOG %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_freq))
-            # Two-OSW private call voice grant/update (sent for duration of the call)
+            # Two-OSW analog private call voice grant/update (sent for duration of the call)
             elif osw1_ch_rx and not osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
                 dst_rid = osw2_addr
                 src_rid = osw1_addr
                 vc_freq = osw1_f_rx
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET PRIVATE CALL src(%05d) dst(%05d) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid, vc_freq))
+                    sys.stderr.write("%s [%d] SMARTNET ANALOG PRIVATE CALL src(%05d) dst(%05d) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid, vc_freq))
             # Two-OSW interconnect call voice grant/update (sent for duration of the call)
             elif osw1_ch_rx and not osw1_grp and (osw1_addr != 0) and (osw2_addr == 0):
                 src_rid = osw1_addr
@@ -1425,6 +1425,13 @@ class osw_receiver(object):
                 rc |= self.update_voice_frequency(osw1_t, vc_freq, dst_tgid, src_rid, mode=1)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET DIGITAL %s GROUP GRANT src(%05d) tgid(%05d/0x%03x) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, self.get_call_options_str(dst_tgid), src_rid, dst_tgid, dst_tgid >> 4, vc_freq))
+            # Two-OSW digital private call voice grant/update (sent for duration of the call)
+            elif osw1_ch_rx and not osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+                dst_rid = osw2_addr
+                src_rid = osw1_addr
+                vc_freq = osw1_f_rx
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DIGITAL PRIVATE CALL src(%05d) dst(%05d) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid, vc_freq))
             # One- or two-OSW system idle
             elif osw1_cmd == 0x2f8:
                 # Get next OSW in the queue

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1099,7 +1099,7 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             status = (osw1_addr & 0x7) + 1
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET STATUS ACK src(%05d) status(%02d)\n" % (log_ts.get(), self.msgq_id, src_rid, status))
+                                sys.stderr.write("%s [%d] SMARTNET STATUS ACK src(%05d) status(%01d)\n" % (log_ts.get(), self.msgq_id, src_rid, status))
                         # Emergency acknowledgement
                         elif osw1_addr == 0x26e8:
                             src_rid = osw2_addr
@@ -1286,7 +1286,7 @@ class osw_receiver(object):
                 if self.debug >= 11:
                     if opcode < 0x8:
                         status = opcode + 1
-                        sys.stderr.write("%s [%d] SMARTNET STATUS src(%05d) tgid(%05d/0x%03x) status(%02d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, status))
+                        sys.stderr.write("%s [%d] SMARTNET STATUS src(%05d) tgid(%05d/0x%03x) status(%01d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, status))
                     elif opcode == 0x8:
                         sys.stderr.write("%s [%d] SMARTNET EMERGENCY src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
                     elif opcode == 0xa:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1079,9 +1079,9 @@ class osw_receiver(object):
                         # Unknown extended function
                         else:
                             tgid = osw2_addr
-                            code = osw1_addr
+                            opcode = osw1_addr
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET GROUP EXTENDED FUNCTION tgid(%05d/0x%03x) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, tgid, tgid >> 4, code))
+                                sys.stderr.write("%s [%d] SMARTNET GROUP EXTENDED FUNCTION tgid(%05d/0x%03x) opcode(0x%04x)\n" % (log_ts.get(), self.msgq_id, tgid, tgid >> 4, opcode))
                     # Extended functions on individuals
                     else:
                         # Radio check
@@ -1275,9 +1275,9 @@ class osw_receiver(object):
                         # Unknown extended function
                         else:
                             src_rid = osw2_addr
-                            code = osw1_addr
+                            opcode = osw1_addr
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) code(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, code))
+                                sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) opcode(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, opcode))
             # Two-OSW status
             elif osw1_cmd == 0x30d and not osw2_grp and not osw1_grp:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1324,7 +1324,7 @@ class osw_receiver(object):
                 dst_rid = osw2_addr
                 src_rid = osw1_addr
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET ANALOG PRIVATE CALL RING ACK src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+                    sys.stderr.write("%s [%d] SMARTNET PRIVATE CALL RING ACK src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
             # Two-OSW call alert
             elif osw1_cmd == 0x319 and not osw2_grp and not osw1_grp:
                 dst_rid = osw2_addr
@@ -1511,12 +1511,6 @@ class osw_receiver(object):
                 src_rid = osw1_addr
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET DIGITAL CLEAR PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
-            # Two-OSW private call ring acknowledgement
-            elif osw1_cmd == 0x318 and not osw2_grp and not osw1_grp:
-                dst_rid = osw2_addr
-                src_rid = osw1_addr
-                if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DIGITAL PRIVATE CALL RING ACK src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
             else:
                 # Track that we got an unknown OSW; OSW1 did not match, so put it back in the queue
                 is_unknown_osw = True

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1836,13 +1836,15 @@ class osw_receiver(object):
 
     def to_json(self):  # ugly but required for compatibility with P25 trunking and terminal modules
         system_id_str = "%04X" % (self.rx_sys_id) if self.rx_sys_id is not None else "----"
-        site_id_str   = "%02d" % (self.rx_site_id) if self.rx_site_id is not None else "--"
 
         d = {}
         d['type']           = 'smartnet'
         d['system']         = self.sysname
-        d['top_line']       = 'SmartNet ' if self.rx_site_id is None else 'SmartZone'
-        d['top_line']      += '   System ID %s  Site %s' % (system_id_str, site_id_str)
+        if self.rx_site_id is None:
+            d['top_line']   = 'SmartNet    System ID %s         ' % (system_id_str)
+        else:
+            site_id_str     = "%02d" % (self.rx_site_id)
+            d['top_line']   = 'SmartZone   System ID %s  Site %s' % (system_id_str, site_id_str)
         d['top_line']      += '   CC %f' % ((self.rx_cc_freq if self.rx_cc_freq is not None else self.cc_list[self.cc_index]) / 1e6)
         d['top_line']      += '   OSW count %d' % (self.stats['osw_count'])
         d['secondary']      = list(self.alternate_cc_freqs.keys())

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1166,6 +1166,11 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET DENIED PRIVATE CALL ENHANCED TARGET OFFLINE src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Radio ID and/or talkgroup forbidden on site
+                        elif osw1_addr == 0x2c4a:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET DENIED FORBIDDEN ON SITE src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
                         # Call alert invalid ID
                         elif osw1_addr == 0x2c4e:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1191,6 +1191,11 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET DENIED OMNILINK TRESPASS src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                        # Denied radio ID
+                        elif osw1_addr == 0x2c65:
+                            src_rid = osw2_addr
+                            if self.debug >= 11:
+                                sys.stderr.write("%s [%d] SMARTNET DENIED RADIO ID src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
                         # Denied talkgroup ID
                         elif osw1_addr == 0x2c66:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1104,7 +1104,7 @@ class osw_receiver(object):
                         elif osw1_addr == 0x26e8:
                             src_rid = osw2_addr
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET EMERGENCY ACK src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                                sys.stderr.write("%s [%d] SMARTNET EMERGENCY ALARM ACK src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
                         # Message acknowledgement
                         elif osw1_addr >= 0x26f0 and osw1_addr <= 0x26ff:
                             src_rid = osw2_addr
@@ -1288,7 +1288,7 @@ class osw_receiver(object):
                         status = opcode + 1
                         sys.stderr.write("%s [%d] SMARTNET STATUS src(%05d) tgid(%05d/0x%03x) status(%01d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, status))
                     elif opcode == 0x8:
-                        sys.stderr.write("%s [%d] SMARTNET EMERGENCY src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
+                        sys.stderr.write("%s [%d] SMARTNET EMERGENCY ALARM src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
                     elif opcode == 0xa:
                         sys.stderr.write("%s [%d] SMARTNET DYNAMIC REGROUP ACK src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
                     else:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1384,14 +1384,30 @@ class osw_receiver(object):
                         sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (ts, self.msgq_id, type_str, osw1_addr, grp1_str, osw1_cmd))
             # Two-OSW date/time
             elif osw1_cmd == 0x322 and osw2_grp and osw1_grp:
-                year   = ((osw2_addr & 0xfe00) >> 9) + 2000
-                month  = (osw2_addr & 0x1e0) >> 5
-                day    = (osw2_addr & 0x1f)
-                data   = (osw1_addr & 0xe000) >> 13
-                hour   = (osw1_addr & 0x1f00) >> 8
-                minute = osw1_addr & 0xff
+                year      = ((osw2_addr & 0xfe00) >> 9) + 2000
+                month     = (osw2_addr & 0x1e0) >> 5
+                day       = (osw2_addr & 0x1f)
+                dayofweek = (osw1_addr & 0xe000) >> 13
+                if dayofweek == 0:
+                    dayofweek_str = "Sunday"
+                elif dayofweek == 1:
+                    dayofweek_str = "Monday"
+                elif dayofweek == 2:
+                    dayofweek_str = "Tuesday"
+                elif dayofweek == 3:
+                    dayofweek_str = "Wednesday"
+                elif dayofweek == 4:
+                    dayofweek_str = "Thursday"
+                elif dayofweek == 5:
+                    dayofweek_str = "Friday"
+                elif dayofweek == 6:
+                    dayofweek_str = "Saturday"
+                else:
+                    dayofweek_str = "unknown day of week"
+                hour      = (osw1_addr & 0x1f00) >> 8
+                minute    = osw1_addr & 0xff
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d data(0x%01x)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, data))
+                    sys.stderr.write("%s [%d] SMARTNET DATE/TIME %04d-%02d-%02d %02d:%02d (%s)\n" % (log_ts.get(), self.msgq_id, year, month, day, hour, minute, dayofweek_str))
             # Two-OSW emergency PTT
             elif osw1_cmd == 0x32e and osw2_grp and osw1_grp:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1546,6 +1546,24 @@ class osw_receiver(object):
             self.rx_site_id = site
             if self.debug >= 11:
                 sys.stderr.write("%s [%d] SMARTNET AMSS site(%02d)%s\n" % (log_ts.get(), self.msgq_id, site, data_str))
+        # One-OSW base station identification / diagnostic
+        elif osw2_cmd == 0x3a0 and osw2_grp:
+            opcode = (osw2_addr & 0xf000) >> 12
+
+            if opcode == 0xe or opcode == 0xf:
+                action_str = "BSI" if opcode == 0xf else "END BSI"
+                if self.debug >= 11:
+                    if self.is_chan(osw2_addr & 0x3ff):
+                        data = (osw2_addr & 0xc00) >> 10
+                        vc_freq = self.get_freq(osw2_addr & 0x3ff)
+                        sys.stderr.write("%s [%d] SMARTNET %s data(0x%01x) vc_freq(%f)\n" % (log_ts.get(), self.msgq_id, action_str, data, vc_freq))
+                    else:
+                        data = osw2_addr & 0xfff
+                        sys.stderr.write("%s [%d] SMARTNET %s data(0x%03x)\n" % (log_ts.get(), self.msgq_id, action_str, data, vc_freq))
+            else:
+                data = osw2_addr & 0x3ff
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DIAGNOSTIC opcode(0x%01x) data(0x%03x)\n" % (log_ts.get(), self.msgq_id, opcode, data))
         # One-OSW system status update
         elif osw2_cmd == 0x3bf or osw2_cmd == 0x3c0:
             scope = "SYSTEM" if osw2_cmd == 0x3c0 else "NETWORK"

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1000,8 +1000,8 @@ class osw_receiver(object):
                     if self.debug >= 11:
                         type_str = "UNKNOWN OSW AFTER BAD OSW" if is_queue_reset else "UNKNOWN OSW"
                         sys.stderr.write("%s [%d] SMARTNET %s (0x%04x,%s,0x%03x)\n" % (log_ts.get(), self.msgq_id, type_str, osw2_addr, grp2_str, osw2_cmd))
-            # Two-OSW dynamic regroup (unknown whether OSWs are group or individual)
-            elif osw1_cmd == 0x30a:
+            # Two-OSW dynamic regroup
+            elif osw1_cmd == 0x30a and not osw2_grp and not osw1_grp:
                 src_rid = osw2_addr
                 tgid = osw1_addr
                 if self.debug >= 11:

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -824,13 +824,14 @@ class osw_receiver(object):
                         sys.stderr.write(" vc_tx_freq(%f)" % (vc_tx_freq))
                     sys.stderr.write("\n")
             # Two-OSW private call voice grant/update (sent for duration of the call)
-            elif osw2_ch_tx and osw1_ch_rx and not osw2_grp and not osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+            elif osw2_ch_tx and osw1_ch_rx and not osw1_grp and (osw1_addr != 0) and (osw2_addr != 0):
+                type_str = "ENCRYPTED" if osw2_grp else "CLEAR"
                 dst_rid = osw2_addr
                 src_rid = osw1_addr
                 vc_rx_freq = osw1_f_rx
                 vc_tx_freq = osw2_f_tx
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET OBT PRIVATE CALL src(%05d) dst(%05d) vc_rx_freq(%f)" % (log_ts.get(), self.msgq_id, src_rid, dst_rid, vc_rx_freq))
+                    sys.stderr.write("%s [%d] SMARTNET OBT %s PRIVATE CALL src(%05d) dst(%05d) vc_rx_freq(%f)" % (log_ts.get(), self.msgq_id, type_str, src_rid, dst_rid, vc_rx_freq))
                     if vc_tx_freq != 0.0:
                         sys.stderr.write(" vc_tx_freq(%f)" % (vc_tx_freq))
                     sys.stderr.write("\n")

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1325,6 +1325,12 @@ class osw_receiver(object):
                 src_rid = osw1_addr
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET CALL ALERT ACK src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+            # Two-OSW OmniLink trespass permitted
+            elif osw1_cmd == 0x31b and not osw2_grp and not osw1_grp:
+                src_rid = osw2_addr
+                system = osw1_addr
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET OMNILINK TRESPASS PERMITTED sys(0x%04x) src(%05d)\n" % (log_ts.get(), self.msgq_id, system, src_rid))
             # Three-OSW system information
             elif osw1_cmd == 0x320:
                 # Get OSW0

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1151,7 +1151,7 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET DENIED UNSUPPORTED MODE src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
-                        # Private call target offline (PC II)
+                        # Private call target offline
                         elif osw1_addr == 0x2c41:
                             src_rid = osw2_addr
                             if self.debug >= 11:
@@ -1161,11 +1161,11 @@ class osw_receiver(object):
                             src_rid = osw2_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET DENIED GROUP BUSY CALL IN PROGRESS src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
-                        # Private call target offline (enhanced)
+                        # Private call ring target offline
                         elif osw1_addr == 0x2c48:
                             src_rid = osw2_addr
                             if self.debug >= 11:
-                                sys.stderr.write("%s [%d] SMARTNET DENIED PRIVATE CALL ENHANCED TARGET OFFLINE src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
+                                sys.stderr.write("%s [%d] SMARTNET DENIED PRIVATE CALL RING TARGET OFFLINE src(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid))
                         # Radio ID and/or talkgroup forbidden on site
                         elif osw1_addr == 0x2c4a:
                             src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1307,12 +1307,18 @@ class osw_receiver(object):
                 message = (osw1_addr & 0xf) + 1
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET MESSAGE src(%05d) tgid(%05d/0x%03x) msg(%02d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, message))
-            # Two-OSW private call ring
+            # Two-OSW encrypted private call ring
+            elif osw1_cmd == 0x315 and not osw2_grp and not osw1_grp:
+                dst_rid = osw2_addr
+                src_rid = osw1_addr
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET ANALOG ENCRYPTED PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+            # Two-OSW clear private call ring
             elif osw1_cmd == 0x317 and not osw2_grp and not osw1_grp:
                 dst_rid = osw2_addr
                 src_rid = osw1_addr
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET ANALOG PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+                    sys.stderr.write("%s [%d] SMARTNET ANALOG CLEAR PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
             # Two-OSW private call ring acknowledgement
             elif osw1_cmd == 0x318 and not osw2_grp and not osw1_grp:
                 dst_rid = osw2_addr
@@ -1493,12 +1499,18 @@ class osw_receiver(object):
                     data = osw1_addr
                     if self.debug >= 11:
                         sys.stderr.write("%s [%d] SMARTNET IDLE DELAYED 1-2 data(%s,0x%04x)\n" % (log_ts.get(), self.msgq_id, grp_str, data))
-            # Two-OSW private call ring
+            # Two-OSW encrypted private call ring
+            elif osw1_cmd == 0x315 and not osw2_grp and not osw1_grp:
+                dst_rid = osw2_addr
+                src_rid = osw1_addr
+                if self.debug >= 11:
+                    sys.stderr.write("%s [%d] SMARTNET DIGITAL ENCRYPTED PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+            # Two-OSW clear private call ring
             elif osw1_cmd == 0x317 and not osw2_grp and not osw1_grp:
                 dst_rid = osw2_addr
                 src_rid = osw1_addr
                 if self.debug >= 11:
-                    sys.stderr.write("%s [%d] SMARTNET DIGITAL PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
+                    sys.stderr.write("%s [%d] SMARTNET DIGITAL CLEAR PRIVATE CALL RING src(%05d) dst(%05d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_rid))
             # Two-OSW private call ring acknowledgement
             elif osw1_cmd == 0x318 and not osw2_grp and not osw1_grp:
                 dst_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1278,16 +1278,21 @@ class osw_receiver(object):
                             opcode = osw1_addr
                             if self.debug >= 11:
                                 sys.stderr.write("%s [%d] SMARTNET INDIVIDUAL EXTENDED FUNCTION src(%05d) opcode(0x%04x)\n" % (log_ts.get(), self.msgq_id, src_rid, opcode))
-            # Two-OSW status
+            # Two-OSW status / emergency / dynamic regroup acknowledgement
             elif osw1_cmd == 0x30d and not osw2_grp and not osw1_grp:
                 src_rid = osw2_addr
                 dst_tgid = osw1_addr & 0xfff0
-                status = (osw1_addr & 0xf) + 1
+                opcode = osw1_addr & 0xf
                 if self.debug >= 11:
-                    if status == 9:
-                        sys.stderr.write("%s [%d] SMARTNET EMERGENCY src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
-                    else:
+                    if opcode < 0x8:
+                        status = opcode + 1
                         sys.stderr.write("%s [%d] SMARTNET STATUS src(%05d) tgid(%05d/0x%03x) status(%02d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, status))
+                    elif opcode == 0x8:
+                        sys.stderr.write("%s [%d] SMARTNET EMERGENCY src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
+                    elif opcode == 0xa:
+                        sys.stderr.write("%s [%d] SMARTNET DYNAMIC REGROUP ACK src(%05d) tgid(%05d/0x%03x)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4))
+                    else:
+                        sys.stderr.write("%s [%d] SMARTNET UNKNOWN STATUS src(%05d) tgid(%05d/0x%03x) opcode(%02d)\n" % (log_ts.get(), self.msgq_id, src_rid, dst_tgid, dst_tgid >> 4, opcode))
             # Two-OSW affiliation
             elif osw1_cmd == 0x310 and not osw2_grp and not osw1_grp:
                 src_rid = osw2_addr

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1639,12 +1639,12 @@ class osw_receiver(object):
                 bit3         = (data & 0x8) >> 3
                 simulcast    = (data & 0x4) >> 2
                 site_trunk   = (data & 0x2) >> 1
-                wide_area    = (data & 0x1)
+                bit0         = (data & 0x1)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d)" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc))
                     if voc or voc_active:
                         sys.stderr.write(" voc_active(%d)" % (voc_active))
-                    sys.stderr.write(" simulcast(%d) site_trunk(%d) wide_area(%d) bit6_5(0x%01x) bit3(%d) bitG(%s)\n" % (simulcast, site_trunk, wide_area, bit6_5, bit3, bitG))
+                    sys.stderr.write(" simulcast(%d) site_trunk(%d) bit6_5(0x%01x) bit3(%d) bit0(%d) bitG(%s)\n" % (simulcast, site_trunk, bit6_5, bit3, bit0, bitG))
             else:
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS opcode(0x%x) data(0x%04x) bitG(%s)\n" % (log_ts.get(), self.msgq_id, scope, grp2_str, opcode, data, bitG))

--- a/op25/gr-op25_repeater/apps/tk_smartnet.py
+++ b/op25/gr-op25_repeater/apps/tk_smartnet.py
@@ -1546,14 +1546,15 @@ class osw_receiver(object):
                 bit6_5       = (data & 0x60) >> 5
                 # Occurs immediately before and after voice grant on VOC
                 voc_active   = (data & 0x10) >> 4
-                bit3_2       = (data & 0xc) >> 2
+                bit3         = (data & 0x8) >> 3
+                simulcast    = (data & 0x4) >> 2
                 site_trunk   = (data & 0x2) >> 1
                 wide_area    = (data & 0x1)
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS rotation(%d) wide_pulse(%d) cvsd_mod(%s) trespass(%d) voc(%d)" % (log_ts.get(), self.msgq_id, scope, rotation, wide_pulse, cvsd_mod_str, trespass, voc))
                     if voc or voc_active:
                         sys.stderr.write(" voc_active(%d)" % (voc_active))
-                    sys.stderr.write(" site_trunk(%d) wide_area(%d) bit6_5(0x%01x) bit3(%d) bitG(%s)\n" % (site_trunk, wide_area, bit6_5, bit3_2, bitG))
+                    sys.stderr.write(" simulcast(%d) site_trunk(%d) wide_area(%d) bit6_5(0x%01x) bit3(%d) bitG(%s)\n" % (simulcast, site_trunk, wide_area, bit6_5, bit3, bitG))
             else:
                 if self.debug >= 11:
                     sys.stderr.write("%s [%d] SMARTNET %s STATUS opcode(0x%x) data(0x%04x) bitG(%s)\n" % (log_ts.get(), self.msgq_id, scope, grp2_str, opcode, data, bitG))


### PR DESCRIPTION
## tl;dr
This PR adds parsing for a variety of new OSWs, which have been inspected using one of two methods:
- personally validated by using an IntelliRepeater site on the bench, or
- received over-the-air and correlated against other circumstantial evidence.

This is a follow-up to #216, and related to #207. It should cleanly merge in parallel with #217.

## New OSWs added
- Digital private call grant/update (differentiate from analog)
- Encrypted OBT private call grant/update (differentiate from clear)
- Encrypted private call ring
- OmniLink trespass permitted
- Base station identification (BSI/"CW ID")
- Diagnostic
    - _Partially decoded, correlates with data from [Trunker](https://wiki.radioreference.com/index.php/Trunker)_
- Roaming
    - _Not sure what exactly it means, but it comes often and correlates with [UniTrunker](https://unitrunker.com/)_

## New extended functions
- Dynamic regroup acknowledgement

## New types of denials added
- Radio ID denied
- Radio ID or talkgroup forbidden on site

## Other improvements
- No longer display a blank site ID for true SmartNet systems
- System/network status:
    - Simulcast bit
    - Remove incorrect `wide_area` bit
- Date/time: day of week
- Dynamic regroup: constrained to correct group/individual bits
- Statuses correctly shown as a single digit
- Corrected "enhanced private call" to "private call ring"

## Acknowledgements
Huge thanks to @alexhanyuan for setting up the IR site on his bench, and for testing many scenarios while I watched remotely on his SDR!