### PR TITLE
Implement Unattended Install for GR310

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ if [ ${GR_VER} = "3.10" ]; then
     echo "Updating packages list"
     sudo apt-get update
     echo "Installing dependencies"
-    sudo apt-get build-dep gnuradio
-    sudo apt-get install gnuradio gnuradio-dev gr-osmosdr librtlsdr-dev libuhd-dev libhackrf-dev libitpp-dev libpcap-dev liborc-dev cmake git build-essential pkg-config doxygen clang-format python3-pybind11 python3-numpy python3-waitress python3-requests gnuplot-x11 libsndfile1-dev libspdlog-dev
+    sudo apt-get build-dep gnuradio -y
+    sudo apt-get install gnuradio gnuradio-dev gr-osmosdr librtlsdr-dev libuhd-dev libhackrf-dev libitpp-dev libpcap-dev liborc-dev cmake git build-essential pkg-config doxygen clang-format python3-pybind11 python3-numpy python3-waitress python3-requests gnuplot-x11 libsndfile1-dev libspdlog-dev -y
 
     # Tell op25 to use python3
     echo "/usr/bin/python3" > op25/gr-op25_repeater/apps/op25_python

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,20 @@ if [ ! -d op25/gr-op25 ]; then
 	exit
 fi
 
+# Initialize variables
+FORCE=false
+
+# Parse command-line arguments
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      FORCE=true
+      ;;
+    *)
+      ;;
+  esac
+done
+
 GR_VER=$(apt list gnuradio 2>/dev/null | grep -m 1 gnuradio | cut -d' ' -f2 | cut -d'.' -f1,2)
 echo "Identified GNURadio version ${GR_VER}"
 if [ ${GR_VER} = "3.10" ]; then
@@ -18,8 +32,8 @@ if [ ${GR_VER} = "3.10" ]; then
     echo "Updating packages list"
     sudo apt-get update
     echo "Installing dependencies"
-    sudo apt-get build-dep gnuradio -y
-    sudo apt-get install gnuradio gnuradio-dev gr-osmosdr librtlsdr-dev libuhd-dev libhackrf-dev libitpp-dev libpcap-dev liborc-dev cmake git build-essential pkg-config doxygen clang-format python3-pybind11 python3-numpy python3-waitress python3-requests gnuplot-x11 libsndfile1-dev libspdlog-dev -y
+    sudo apt-get build-dep gnuradio $([ "$FORCE" = true ] && echo "-y")
+    sudo apt-get install gnuradio gnuradio-dev gr-osmosdr librtlsdr-dev libuhd-dev libhackrf-dev libitpp-dev libpcap-dev liborc-dev cmake git build-essential pkg-config doxygen clang-format python3-pybind11 python3-numpy python3-waitress python3-requests gnuplot-x11 libsndfile1-dev libspdlog-dev $([ "$FORCE" = true ] && echo "-y")
 
     # Tell op25 to use python3
     echo "/usr/bin/python3" > op25/gr-op25_repeater/apps/op25_python


### PR DESCRIPTION
This PR implements a simple QoL improvement to allow the `install.sh` script to run unattended. This is useful for multi-node, remote, containerized or other headless setups.

The user can choose to force the script using the `-f` flag, EX: `./install.sh -f`