### PR TITLE
Fix tx after Motorola Widepulse support

### DIFF
--- a/op25/gr-op25_repeater/apps/tx/op25_c4fm_mod.py
+++ b/op25/gr-op25_repeater/apps/tx/op25_c4fm_mod.py
@@ -65,7 +65,7 @@ def transfer_function_rx(symbol_rate=_def_symbol_rate, rate_multiplier=1.0):
 		xfer.append(df)
 	return xfer
 
-def transfer_function_tx(symbol_rate=_def_symbol_rate):
+def transfer_function_tx(symbol_rate=_def_symbol_rate, rate_multiplier=1.0):
 	xfer = []	# frequency domain transfer function
 	for f in range(0, 2881):	# specs cover 0 - 2,880 Hz
 		# H(f)
@@ -245,7 +245,7 @@ class p25_mod_bf(gr.hier_block2):
             coeffs = gmsk_taps(sample_rate=intermediate_rate, bt=self.bt).generate()
         elif not rc:
             coeffs = c4fm_taps(sample_rate=intermediate_rate, generator=self.generator).generate()
-        self.filter = filter.interp_fir_filter_fff(self._interp_factor, coeffs)
+        self.filter = filter.interp_fir_filter_fff(int(self._interp_factor), coeffs)
 
         if verbose:
             self._print_verbage()


### PR DESCRIPTION
Fix for transfer_function_tx

Demodulator changes to support Motorola Widepulse e1ae5624d1e3a5ca305273f302fd41fbc6f8296f
for Patch from Max for Motorola Widepulse fc35ad9dd5edb8fa521cf26891e700ef18d1ad17
add changes **only** for `transfer_function`**_rx**