### PR TITLE
Fix boost compilation error

### DIFF
--- a/op25/gr-op25_repeater/lib/iqfile_source_impl.cc
+++ b/op25/gr-op25_repeater/lib/iqfile_source_impl.cc
@@ -185,14 +185,14 @@ void iqfile_source_impl::open(const char* filename,
     }
 
     if ((d_new_fp = fopen(filename, "rb")) == NULL) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+	GR_LOG_ERROR(d_logger, fmt::format("{}: {}", filename, strerror(errno)));
         throw std::runtime_error("can't open file");
     }
 
     struct GR_STAT st;
 
     if (GR_FSTAT(GR_FILENO(d_new_fp), &st)) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+	GR_LOG_ERROR(d_logger, fmt::format("{}: {}", filename, strerror(errno)));
         throw std::runtime_error("can't fstat file");
     }
     if (S_ISREG(st.st_mode)) {


### PR DESCRIPTION
I had compilation errors (running ./install.sh failed) and ChatGPT advised me to make this change. TBH I don't quite know what I am doing, but with this patch I can build on Ubuntu 24.04. Please feel free to accept or reject or discuss as appropriate. Please let me know if you would like the original error logs I am happy to debug why boost was throwing errors.