### PR TITLE
Raise CMake minimum version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 project(gr-op25 CXX C)
 enable_testing()
 

--- a/op25/gr-op25/CMakeLists.txt
+++ b/op25/gr-op25/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(gr-op25 CXX C)
 enable_testing()
 

--- a/op25/gr-op25_repeater/CMakeLists.txt
+++ b/op25/gr-op25_repeater/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(gr-op25_repeater CXX C)
 enable_testing()
 
@@ -150,4 +150,3 @@ configure_package_config_file(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/Modules/${target}Config.cmake
     INSTALL_DESTINATION ${GR_CMAKE_DIR}
 )
-

--- a/op25/gr-op25_repeater/lib/imbe_vocoder/CMakeLists.txt
+++ b/op25/gr-op25_repeater/lib/imbe_vocoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 
 SET( MORE_FLAGS "-fPIC")
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${MORE_FLAGS}" )


### PR DESCRIPTION
This will fix a lot of build errors people are having. I picked 3.20 but this is easily change if some distros are still using older versions of CMake.