### PR TITLE
Fix op25_audio destructor crash when websocket thread never started

### DIFF
--- a/op25/gr-op25_repeater/lib/op25_audio.cc
+++ b/op25/gr-op25_repeater/lib/op25_audio.cc
@@ -410,6 +410,8 @@ void op25_audio::ws_start()
 // websocket graceful shutdown
 void op25_audio::ws_stop()
 {
+    if (!d_ws_enabled || !ws_thread.joinable())
+        return;  // never started — destructor calls this unconditionally
     fprintf(stderr, "%s op25_audio::op25_audio: Shutting down websocket server on port %d\n", logts.get(d_msgq_id), d_ws_port);
     d_ws_endpt.stop_listening();
     for (auto & hdl : d_ws_connections) {


### PR DESCRIPTION
The `op25_audio` destructor unconditionally joins the websocket thread, but the thread is only created lazily when websocket output is enabled in the runtime config. If the destructor runs before any audio is ever processed (or with websocket output disabled), `pthread_join` is called on an unstarted `std::thread` and the process aborts.

Guard the join with `joinable()` so the destructor is safe in all configurations.

Hit while running `multi_rx.py` in scan-and-exit scenarios where receivers are torn down before any audio flows.