### PR TITLE
Add fec_stats command for FEC quality diagnostics

### DIFF
--- a/op25/gr-op25_repeater/include/gnuradio/op25_repeater/frame_assembler.h
+++ b/op25/gr-op25_repeater/include/gnuradio/op25_repeater/frame_assembler.h
@@ -50,7 +50,7 @@ namespace gr {
                  */
                 static sptr make(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
                 virtual void set_debug(int debug) {}
-                virtual void control(const std::string& args) {}
+                virtual std::string control(const std::string& args) { return {}; }
         };
 
     } // namespace op25_repeater

--- a/op25/gr-op25_repeater/include/gnuradio/op25_repeater/p25_frame_assembler.h
+++ b/op25/gr-op25_repeater/include/gnuradio/op25_repeater/p25_frame_assembler.h
@@ -50,7 +50,7 @@ namespace gr {
        */
       static sptr make(const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
       virtual void set_debug(int debug) {}
-      virtual void control(const std::string& args) {}
+      virtual std::string control(const std::string& args) { return {}; }
     };
 
   } // namespace op25_repeater

--- a/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
+++ b/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
@@ -82,10 +82,12 @@ namespace gr {
                     d_sync->set_debug(j["debug"].get<int>());
             } else if (cmd == "crypt_behavior") {
 			    if (d_sync)
-			        d_sync->crypt_behavior(j["behavior"].get<int>());	
+			        d_sync->crypt_behavior(j["behavior"].get<int>());
 			} else if (cmd == "dump_buffer") {
 			    if (d_sync)
                     d_sync->dump_buffer();
+            } else if (cmd == "fec_stats") {
+                return d_sync ? d_sync->get_fec_stats_json() : std::string{};
             } else {
                 if (d_debug >= 10) {
                     fprintf(stderr, "%s frame_assembler_impl::control: unhandled cmd(%s)\n", logts.get(d_msgq_id), cmd.c_str());

--- a/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
+++ b/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
@@ -43,8 +43,10 @@ using json = nlohmann::json;
 namespace gr {
     namespace op25_repeater {
 
-        // Accept and dispatch JSON formatted commands from python
-        void frame_assembler_impl::control(const std::string& args) {
+        // Accept and dispatch JSON formatted commands from python.
+        // Returns a JSON-encoded response string for commands that produce
+        // output, or an empty string for commands that don't.
+        std::string frame_assembler_impl::control(const std::string& args) {
             json j = json::parse(args);
             std::string cmd = j["cmd"].get<std::string>();
             if (d_debug >= 10) {
@@ -89,6 +91,7 @@ namespace gr {
                     fprintf(stderr, "%s frame_assembler_impl::control: unhandled cmd(%s)\n", logts.get(d_msgq_id), cmd.c_str());
                 }
             }
+            return {};
         }
 
         void frame_assembler_impl::set_debug(int debug) {

--- a/op25/gr-op25_repeater/lib/frame_assembler_impl.h
+++ b/op25/gr-op25_repeater/lib/frame_assembler_impl.h
@@ -50,7 +50,7 @@ namespace gr {
                 // internal functions
                 void queue_msg(int duid);
                 void set_debug(int debug);
-                void control(const std::string& args);
+                std::string control(const std::string& args);
 
             public:
                 log_ts logts;

--- a/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -47,8 +47,10 @@ namespace gr {
             p2tdma.set_debug(debug);
         }
 
-        // Accept and dispatch JSON formatted commands from python
-        void p25_frame_assembler_impl::control(const std::string& args) {
+        // Accept and dispatch JSON formatted commands from python.
+        // Returns a JSON-encoded response string for commands that produce
+        // output, or an empty string for commands that don't.
+        std::string p25_frame_assembler_impl::control(const std::string& args) {
             json j = json::parse(args);
             std::string cmd = j["cmd"].get<std::string>();
             if (d_debug >= 10) {
@@ -88,6 +90,7 @@ namespace gr {
                     fprintf(stderr, "%s p25_frame_assembler_impl::control: unhandled cmd(%s)\n", logts.get(0), cmd.c_str());
                 }
             }
+            return {};
         }
 
         p25_frame_assembler::sptr

--- a/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.h
+++ b/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.h
@@ -54,7 +54,7 @@ namespace gr {
 
             // internal functions
             void set_debug(int debug) ;
-            void control(const std::string& args);
+            std::string control(const std::string& args);
 
         public:
             log_ts logts;

--- a/op25/gr-op25_repeater/lib/p25p1_fdma.cc
+++ b/op25/gr-op25_repeater/lib/p25p1_fdma.cc
@@ -452,11 +452,13 @@ namespace gr {
         void p25p1_fdma::process_TSBK(const bit_vector& fr, uint32_t fr_len) {
             uint8_t op, lb = 0;
             block_vector deinterleave_buf;
+            d_stat_tsbk_attempted++;
             if (process_blocks(fr, fr_len, deinterleave_buf) == 0) {
                 for (size_t j = 0; (j < deinterleave_buf.size()) && (lb == 0); j++) {
                     if (crc16(deinterleave_buf[j].data(), 12) != 0) // validate CRC
                         return;
 
+                    if (j == 0) d_stat_tsbk_passed++;  // count once per TSBK call
                     lb = deinterleave_buf[j][0] >> 7;	// last block flag
                     op = deinterleave_buf[j][0] & 0x3f;	// opcode
                     process_duid(framer->duid, framer->nac, deinterleave_buf[j].data(), 10);
@@ -475,10 +477,12 @@ namespace gr {
         void p25p1_fdma::process_PDU(const bit_vector& fr, uint32_t fr_len) {
             uint8_t fmt, sap, blks, op = 0;
             block_vector deinterleave_buf;
+            d_stat_pdu_attempted++;
             if ((process_blocks(fr, fr_len, deinterleave_buf) == 0) &&
                     (deinterleave_buf.size() > 0)) {			// extract all blocks associated with this PDU
                 if (crc16(deinterleave_buf[0].data(), 12) != 0) // validate PDU header
                     return;
+                d_stat_pdu_passed++;
 
                 fmt =  deinterleave_buf[0][0] & 0x1f;
                 sap =  deinterleave_buf[0][1] & 0x3f;
@@ -771,6 +775,7 @@ namespace gr {
                     }
 
                     qtimer.reset();
+                    d_stat_timeouts++;
                     gr::message::sptr msg = gr::message::make(get_msg_type(PROTOCOL_P25, M_P25_TIMEOUT), (d_msgq_id << 1), logts.get_ts());
                     if (!d_msg_queue->full_p())
                         d_msg_queue->insert_tail(msg);

--- a/op25/gr-op25_repeater/lib/p25p1_fdma.h
+++ b/op25/gr-op25_repeater/lib/p25p1_fdma.h
@@ -97,6 +97,13 @@ namespace gr {
                 uint8_t  ess_mi[9] = {0};
                 uint16_t vf_tgid;
 
+                // FEC counters surfaced via fec_stats control() command.
+                uint64_t d_stat_tsbk_attempted = 0;
+                uint64_t d_stat_tsbk_passed = 0;
+                uint64_t d_stat_pdu_attempted = 0;
+                uint64_t d_stat_pdu_passed = 0;
+                uint64_t d_stat_timeouts = 0;
+
             public:
                 void set_debug(int debug);
                 void set_nac(int nac);
@@ -110,6 +117,12 @@ namespace gr {
                 ~p25p1_fdma();
                 uint32_t load_nid(const uint8_t *syms, int nsyms, const uint64_t fs);
                 bool load_body(const uint8_t * syms, int nsyms);
+
+                uint64_t stat_tsbk_attempted() const { return d_stat_tsbk_attempted; }
+                uint64_t stat_tsbk_passed()    const { return d_stat_tsbk_passed; }
+                uint64_t stat_pdu_attempted()  const { return d_stat_pdu_attempted; }
+                uint64_t stat_pdu_passed()     const { return d_stat_pdu_passed; }
+                uint64_t stat_timeouts()       const { return d_stat_timeouts; }
 
                 // Where all the action really happens
 

--- a/op25/gr-op25_repeater/lib/rx_base.h
+++ b/op25/gr-op25_repeater/lib/rx_base.h
@@ -41,6 +41,10 @@ namespace gr {
                 // Crypt_behavior
                 virtual void set_xormask(const char* p) = 0;
                 virtual void crypt_behavior(int behavior) = 0;
+                // FEC stats: JSON envelope returned to {"cmd":"fec_stats"} via
+                // frame_assembler::control(). Default empty so non-P25 sync types
+                // (Smartnet, subchannel) report nothing.
+                virtual std::string get_fec_stats_json() const { return {}; }
                 rx_base(const char * options, log_ts& logger, int debug, int msgq_id, gr::msg_queue::sptr queue) { };
                 rx_base() {}; // default constructor called by derived classes
                 virtual ~rx_base() {};

--- a/op25/gr-op25_repeater/lib/rx_sync.cc
+++ b/op25/gr-op25_repeater/lib/rx_sync.cc
@@ -32,6 +32,8 @@
 
 #include "rx_sync.h"
 
+#include <nlohmann/json.hpp>
+
 #include "bit_utils.h"
 
 #include "check_frame_sync.h"
@@ -155,6 +157,27 @@ void rx_sync::set_debug(int debug) {
 	p25fdma.set_debug(debug);
 	p25tdma.set_debug(debug);
 	dmr.set_debug(debug);
+}
+
+// Build the FEC stats JSON envelope. Counters are monotonic since
+// construction; consumers diff between samples to compute rates.
+std::string rx_sync::get_fec_stats_json() const {
+	nlohmann::json envelope = {
+		{"cmd", "fec_stats"},
+		{"schema", 1},
+		{"data", {
+			{"control", {
+				{"tsbk_attempted",  p25fdma.stat_tsbk_attempted()},
+				{"tsbk_crc_passed", p25fdma.stat_tsbk_passed()},
+				{"pdu_attempted",   p25fdma.stat_pdu_attempted()},
+				{"pdu_crc_passed",  p25fdma.stat_pdu_passed()},
+			}},
+			{"sync", {
+				{"losses", p25fdma.stat_timeouts()},
+			}},
+		}},
+	};
+	return envelope.dump();
 }
 
 static int ysf_decode_fich(const uint8_t src[100], uint8_t dest[32]) {   // input is 100 dibits, result is 32 bits

--- a/op25/gr-op25_repeater/lib/rx_sync.h
+++ b/op25/gr-op25_repeater/lib/rx_sync.h
@@ -137,6 +137,7 @@ public:
 	void crypt_behavior(int behavior);
 	void set_debug(int debug);
     void dump_buffer();
+	std::string get_fec_stats_json() const;
 	rx_sync(const char * options, log_ts& logger, int debug, int msgq_id, gr::msg_queue::sptr queue);
 	~rx_sync();
 

--- a/op25/gr-op25_repeater/python/op25_repeater/bindings/frame_assembler_python.cc
+++ b/op25/gr-op25_repeater/python/op25_repeater/bindings/frame_assembler_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(frame_assembler.h) */
-/* BINDTOOL_HEADER_FILE_HASH(039ddef878982559df6298d2cbbe8747) */
+/* BINDTOOL_HEADER_FILE_HASH(376a76b96be75803eee2cdde1157b3b7) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/op25/gr-op25_repeater/python/op25_repeater/bindings/p25_frame_assembler_python.cc
+++ b/op25/gr-op25_repeater/python/op25_repeater/bindings/p25_frame_assembler_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(p25_frame_assembler.h) */
-/* BINDTOOL_HEADER_FILE_HASH(1a2507e84c52b9f629ebbeb6a9afe6c7) */
+/* BINDTOOL_HEADER_FILE_HASH(ef4065c3e74cc8cb0bf7cbba14b22cfe) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Reworked per the design discussion. Depends on #273 (the `control()` signature change) — that lands first, then this rebases down to a single commit and the diff for this PR collapses to the fec_stats addition only.

Currently shows 2 commits: the #273 signature change and the new fec_stats commit. Once #273 merges to `dev`, GitHub will drop the first one from this PR's view automatically.

## What this does

Counts P25 FDMA control-channel FEC results and surfaces them via the `control()` JSON channel. Each call to `{"cmd":"fec_stats"}` returns a JSON envelope of monotonic counters; consumers diff between samples to compute rates without op25 having to take a permanent position on what window or what "BER" means.

```json
{
  "cmd": "fec_stats",
  "schema": 1,
  "data": {
    "control": {
      "tsbk_attempted":  N,
      "tsbk_crc_passed": N,
      "pdu_attempted":   N,
      "pdu_crc_passed":  N
    },
    "sync": {
      "losses": N
    }
  }
}
```

Block-level CRC pass rate is a reasonable BER proxy: trellis-coded TSBK blocks fail CRC when post-FEC residual errors remain, and the rate correlates with link quality independent of received signal strength.

## What changed vs. the original PR

Out, per your indigestion-with-pybind11 concern:

- ❌ `op25_decode_stats` struct in the public `frame_assembler.h`
- ❌ `get_decode_stats()` virtual on the public `frame_assembler` interface
- ❌ `op25_decode_stats` pybind11 class binding
- ❌ `.def(\"get_decode_stats\", ...)` pybind11 method binding
- ❌ `BINDTOOL_HEADER_FILE_HASH` change in `frame_assembler_python.cc`

In, replacing them:

- ✅ `virtual std::string get_fec_stats_json()` on `rx_base` (internal, in `lib/`, no Python exposure)
- ✅ Override in `rx_sync` that builds the envelope; nlohmann/json dependency confined to `rx_sync.cc`
- ✅ A new `cmd == \"fec_stats\"` branch in `frame_assembler_impl::control()` that delegates and returns the JSON

Net: the public ABI grows by zero new exports. The Python surface grows by one command name. No new pybind11 bindings.

## What's not yet here

Schema sketched out room for `voice` (golay_corrected, rs_corrected, rs_unrecoverable) and `sync.acquisitions`. None of those have instrumentation in the FEC path today — they'd need new counters in the voice decoder and sync state machine. Easier as a follow-up under the same `schema: 1` contract (forward-compatible additions). Happy to do those next if useful, or leave them until there's a concrete consumer.

## Files

- `lib/p25p1_fdma.{h,cc}` — 5 monotonic counters + inline const accessors. Increments in `process_TSBK` / `process_PDU` around CRC checks, and in `check_timeout` for sync timeouts.
- `lib/rx_base.h` — internal virtual default empty.
- `lib/rx_sync.{h,cc}` — override that builds the JSON envelope from `p25fdma` counters.
- `lib/frame_assembler_impl.cc` — one new branch in the dispatch.