### PR TITLE
Change frame_assembler::control() return type from void to std::string

### DIFF
--- a/op25/gr-op25_repeater/include/gnuradio/op25_repeater/frame_assembler.h
+++ b/op25/gr-op25_repeater/include/gnuradio/op25_repeater/frame_assembler.h
@@ -50,7 +50,7 @@ namespace gr {
                  */
                 static sptr make(const char* options, int debug, int msgq_id, gr::msg_queue::sptr queue);
                 virtual void set_debug(int debug) {}
-                virtual void control(const std::string& args) {}
+                virtual std::string control(const std::string& args) { return {}; }
         };
 
     } // namespace op25_repeater

--- a/op25/gr-op25_repeater/include/gnuradio/op25_repeater/p25_frame_assembler.h
+++ b/op25/gr-op25_repeater/include/gnuradio/op25_repeater/p25_frame_assembler.h
@@ -50,7 +50,7 @@ namespace gr {
        */
       static sptr make(const char* udp_host, int port, int debug, bool do_imbe, bool do_output, bool do_msgq, gr::msg_queue::sptr queue, bool do_audio_output, bool do_phase2_tdma, bool do_nocrypt);
       virtual void set_debug(int debug) {}
-      virtual void control(const std::string& args) {}
+      virtual std::string control(const std::string& args) { return {}; }
     };
 
   } // namespace op25_repeater

--- a/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
+++ b/op25/gr-op25_repeater/lib/frame_assembler_impl.cc
@@ -43,8 +43,10 @@ using json = nlohmann::json;
 namespace gr {
     namespace op25_repeater {
 
-        // Accept and dispatch JSON formatted commands from python
-        void frame_assembler_impl::control(const std::string& args) {
+        // Accept and dispatch JSON formatted commands from python.
+        // Returns a JSON-encoded response string for commands that produce
+        // output, or an empty string for commands that don't.
+        std::string frame_assembler_impl::control(const std::string& args) {
             json j = json::parse(args);
             std::string cmd = j["cmd"].get<std::string>();
             if (d_debug >= 10) {
@@ -89,6 +91,7 @@ namespace gr {
                     fprintf(stderr, "%s frame_assembler_impl::control: unhandled cmd(%s)\n", logts.get(d_msgq_id), cmd.c_str());
                 }
             }
+            return {};
         }
 
         void frame_assembler_impl::set_debug(int debug) {

--- a/op25/gr-op25_repeater/lib/frame_assembler_impl.h
+++ b/op25/gr-op25_repeater/lib/frame_assembler_impl.h
@@ -50,7 +50,7 @@ namespace gr {
                 // internal functions
                 void queue_msg(int duid);
                 void set_debug(int debug);
-                void control(const std::string& args);
+                std::string control(const std::string& args);
 
             public:
                 log_ts logts;

--- a/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.cc
+++ b/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.cc
@@ -47,8 +47,10 @@ namespace gr {
             p2tdma.set_debug(debug);
         }
 
-        // Accept and dispatch JSON formatted commands from python
-        void p25_frame_assembler_impl::control(const std::string& args) {
+        // Accept and dispatch JSON formatted commands from python.
+        // Returns a JSON-encoded response string for commands that produce
+        // output, or an empty string for commands that don't.
+        std::string p25_frame_assembler_impl::control(const std::string& args) {
             json j = json::parse(args);
             std::string cmd = j["cmd"].get<std::string>();
             if (d_debug >= 10) {
@@ -88,6 +90,7 @@ namespace gr {
                     fprintf(stderr, "%s p25_frame_assembler_impl::control: unhandled cmd(%s)\n", logts.get(0), cmd.c_str());
                 }
             }
+            return {};
         }
 
         p25_frame_assembler::sptr

--- a/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.h
+++ b/op25/gr-op25_repeater/lib/p25_frame_assembler_impl.h
@@ -54,7 +54,7 @@ namespace gr {
 
             // internal functions
             void set_debug(int debug) ;
-            void control(const std::string& args);
+            std::string control(const std::string& args);
 
         public:
             log_ts logts;

--- a/op25/gr-op25_repeater/python/op25_repeater/bindings/frame_assembler_python.cc
+++ b/op25/gr-op25_repeater/python/op25_repeater/bindings/frame_assembler_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(frame_assembler.h) */
-/* BINDTOOL_HEADER_FILE_HASH(039ddef878982559df6298d2cbbe8747) */
+/* BINDTOOL_HEADER_FILE_HASH(376a76b96be75803eee2cdde1157b3b7) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/op25/gr-op25_repeater/python/op25_repeater/bindings/p25_frame_assembler_python.cc
+++ b/op25/gr-op25_repeater/python/op25_repeater/bindings/p25_frame_assembler_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(p25_frame_assembler.h) */
-/* BINDTOOL_HEADER_FILE_HASH(1a2507e84c52b9f629ebbeb6a9afe6c7) */
+/* BINDTOOL_HEADER_FILE_HASH(ef4065c3e74cc8cb0bf7cbba14b22cfe) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Mechanical signature widen, no behavior change. Splits out from #272 per your suggestion to land it on its own first.

## Why

Future commands routed through `control()` will need to return data — FEC stats from #272 being the first. Widening the signature once now avoids having to add a new pybind11 entry point every time we add a query-style command.

## What changes

```cpp
virtual void        control(const std::string& args) {}
-> virtual std::string control(const std::string& args) { return {}; }
```

Touches only the two block classes:

- `include/gnuradio/op25_repeater/frame_assembler.h` — base virtual
- `include/gnuradio/op25_repeater/p25_frame_assembler.h` — base virtual
- `lib/frame_assembler_impl.{h,cc}` — declaration + definition; dispatch returns `{}` at the end since no existing command produces output
- `lib/p25_frame_assembler_impl.{h,cc}` — same
- `python/op25_repeater/bindings/frame_assembler_python.cc` — `BINDTOOL_HEADER_FILE_HASH` refreshed
- `python/op25_repeater/bindings/p25_frame_assembler_python.cc` — same

The `.def("control", ...)` registration in the bindings is unchanged: pybind11 deduces the return type from the function pointer, so Python now receives a `str` instead of `None`. Existing call sites that ignore the return value continue to work as before.

## Why C++17 makes this free

- C++17 mandates copy elision for `return local;` — the local is constructed directly in the caller's storage (zero copies).
- When elision can't apply, the compiler implicitly moves — a `std::string` move is a pointer steal, no heap traffic.
- `return {};` hits SSO, no allocation.
- The pybind11 boundary copies/moves into a Python `str` either way.

## Follow-up

#272 will be reworked on top of this branch: drop the `op25_decode_stats` struct, drop the new pybind11 additions, drop the `get_decode_stats()` virtual, and instead route `{"cmd":"fec_stats"}` through `control()` and return the JSON envelope we discussed.