### PR TITLE
Fix file handle leak and bare except clauses in http_server.py

### DIFF
--- a/op25/gr-op25_repeater/apps/http_server.py
+++ b/op25/gr-op25_repeater/apps/http_server.py
@@ -59,7 +59,8 @@ def static_file(environ, start_response):
         content_type = 'text/plain'
         output = status
     else:
-        output = open(pathname, 'rb').read()
+        with open(pathname, 'rb') as f:
+            output = f.read()
         content_type = content_types[suf]
         status = '200 OK'
     return status, content_type, output

--- a/op25/gr-op25_repeater/apps/http_server.py
+++ b/op25/gr-op25_repeater/apps/http_server.py
@@ -75,7 +75,7 @@ def post_req(environ, start_response, postdata):
                 my_output_q.insert_tail(msg)
         valid_req = True
         time.sleep(0.2)
-    except:
+    except (json.JSONDecodeError, KeyError, TypeError):
         sys.stderr.write('post_req: error processing input: %s\n%s\n' % (postdata, traceback.format_exc()))
 
     resp_msg = []
@@ -116,7 +116,7 @@ def application(environ, start_response):
     failed = False
     try:
         result = http_request(environ, start_response)
-    except:
+    except Exception:
         failed = True
         sys.stderr.write('application: request failed:\n%s\n' % traceback.format_exc())
         sys.exit(1)
@@ -145,7 +145,7 @@ class http_server(object):
 
         try:
             self.server = create_server(application, host=host, port=my_port, threads=6)
-        except:
+        except (OSError, ValueError):
             sys.stderr.write('Failed to create http terminal server\n%s\n' % traceback.format_exc())
             sys.exit(1)
 


### PR DESCRIPTION
Replace bare except: clauses with specific exception types

- `post_req()`: use `except (json.JSONDecodeError, KeyError, TypeError)` to catch
  malformed JSON and missing required fields without masking unrelated errors or
  swallowing KeyboardInterrupt/SystemExit
- `application()`: use `except Exception` as a last-resort handler before sys.exit(1)
- `http_server.__init__()`: use `except (OSError, ValueError)` for server creation
  failures (e.g. port already in use, bad host/port values)

Fix file handle leak in static_file()
- Replace `open(pathname, 'rb').read()` with a `with` statement to ensure the file
  is always closed after reading