### PR TITLE
Fix op25_audio WebSocket thread safety and enabled() gate

### DIFF
--- a/op25/gr-op25_repeater/lib/op25_audio.cc
+++ b/op25/gr-op25_repeater/lib/op25_audio.cc
@@ -318,6 +318,7 @@ void op25_audio::ws_open_handler(websocketpp::connection_hdl hdl)
     if (!ec) {
         fprintf(stderr, "%s op25_audio::op25_audio: websocket connection from [%s] opened on port [%d]\n", logts.get(d_msgq_id), con->get_host().c_str(), con->get_port());
     }
+    std::lock_guard<std::mutex> lock(d_ws_mutex);
     d_ws_connections.push_back(hdl);
 }
 
@@ -329,6 +330,7 @@ void op25_audio::ws_close_handler(websocketpp::connection_hdl hdl)
     if (!ec) {
         fprintf(stderr, "%s op25_audio::op25_audio: websocket connection from [%s] closed on port [%d]\n", logts.get(d_msgq_id), con->get_host().c_str(), con->get_port());
     }
+    std::lock_guard<std::mutex> lock(d_ws_mutex);
     auto it = std::find_if(d_ws_connections.begin(), d_ws_connections.end(), [&hdl](const websocketpp::connection_hdl& ptr1) {
         return ptr1.lock() == hdl.lock();
     } );
@@ -346,6 +348,7 @@ void op25_audio::ws_fail_handler(websocketpp::connection_hdl hdl)
     if (!ec) {
         fprintf(stderr, "%s op25_audio::op25_audio: websocket connection from [%s] failed on port [%d]\n", logts.get(d_msgq_id), con->get_host().c_str(), con->get_port());
     }
+    std::lock_guard<std::mutex> lock(d_ws_mutex);
     auto it = std::find_if(d_ws_connections.begin(), d_ws_connections.end(), [&hdl](const websocketpp::connection_hdl& ptr1) {
         return ptr1.lock() == hdl.lock();
     } );
@@ -358,6 +361,7 @@ void op25_audio::ws_fail_handler(websocketpp::connection_hdl hdl)
 // websocket send audio message to clients
 void op25_audio::ws_send_audio(const void *buf, size_t len)
 {
+    std::lock_guard<std::mutex> lock(d_ws_mutex);
     websocketpp::lib::error_code ec;
     for (auto & hdl : d_ws_connections) {
         if ( hdl.expired() )
@@ -387,6 +391,7 @@ void op25_audio::ws_send_audio_flag(const udpFlagEnumType udp_flag)
             return;
     }
 
+    std::lock_guard<std::mutex> lock(d_ws_mutex);
     websocketpp::lib::error_code ec;
     for (auto & hdl : d_ws_connections) {
         if ( hdl.expired() )
@@ -414,10 +419,13 @@ void op25_audio::ws_stop()
         return;  // never started — destructor calls this unconditionally
     fprintf(stderr, "%s op25_audio::op25_audio: Shutting down websocket server on port %d\n", logts.get(d_msgq_id), d_ws_port);
     d_ws_endpt.stop_listening();
-    for (auto & hdl : d_ws_connections) {
-        if ( hdl.expired() )
-            continue;
-        d_ws_endpt.close(hdl, 1001, "Shutting down");
+    {
+        std::lock_guard<std::mutex> lock(d_ws_mutex);
+        for (auto & hdl : d_ws_connections) {
+            if ( hdl.expired() )
+                continue;
+            d_ws_endpt.close(hdl, 1001, "Shutting down");
+        }
     }
     ws_thread.join();
 }

--- a/op25/gr-op25_repeater/lib/op25_audio.h
+++ b/op25/gr-op25_repeater/lib/op25_audio.h
@@ -26,6 +26,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -67,6 +68,7 @@ private:
     std::thread ws_thread;
     websocketpp::server<websocketpp::config::asio> d_ws_endpt;
     std::vector<websocketpp::connection_hdl> d_ws_connections;
+    std::mutex  d_ws_mutex;
     void        ws_msg_handler(websocketpp::connection_hdl hdl, websocketpp::server<websocketpp::config::asio>::message_ptr msg);
     void        ws_open_handler(websocketpp::connection_hdl hdl);
     void        ws_close_handler(websocketpp::connection_hdl hdl);

--- a/op25/gr-op25_repeater/lib/op25_audio.h
+++ b/op25/gr-op25_repeater/lib/op25_audio.h
@@ -81,7 +81,7 @@ public:
     op25_audio(const char* destination, log_ts& logger, int debug, int msgq_id);
     ~op25_audio();
 
-    inline bool enabled() const { return d_udp_enabled; }
+    inline bool enabled() const { return d_udp_enabled || d_ws_enabled; }
     inline void set_debug(int debug) { d_debug = debug; }
 
     ssize_t     send_to(const void *buf, size_t len);


### PR DESCRIPTION
## Summary

- **`op25_audio::enabled()` returns false for WebSocket-only configs** — the method only checked `d_udp_enabled`, so callers like `p25p1_fdma` that gate audio routing on `enabled()` would silently drop IMBE (Phase 1) audio frames when no UDP destination is configured, even with a WebSocket server running. Fixed to `return d_udp_enabled || d_ws_enabled`.

- **Data race on `d_ws_connections`** — the GNU Radio audio thread calls `ws_send_audio()` and `ws_send_audio_flag()` (iterating the vector), while the websocketpp asio event loop thread calls `ws_open_handler()`, `ws_close_handler()`, and `ws_fail_handler()` (modifying the vector). This is an unsynchronized concurrent access. Added `std::mutex d_ws_mutex` to `op25_audio` and a `std::lock_guard` at each of the six access sites, including the shutdown loop in `ws_stop()`.

## Test plan

- [ ] Build with a WebSocket-only config (`destination: ws://...`) — audio routes correctly for both Phase 1 IMBE and Phase 2 AMBE+2 calls
- [ ] UDP-only config — `enabled()` and `d_udp_enabled` path unchanged, no regression
