### PR TITLE
Fix WebSocket server port leak on shutdown

### DIFF
--- a/op25/gr-op25_repeater/lib/op25_audio.cc
+++ b/op25/gr-op25_repeater/lib/op25_audio.cc
@@ -183,6 +183,7 @@ op25_audio::op25_audio(const char* destination, log_ts& logger, int debug, int m
             d_ws_endpt.set_message_handler(std::bind(&op25_audio::ws_msg_handler, this, std::placeholders::_1, std::placeholders::_2));
             d_ws_host = dest_url.host;
             d_ws_port = std::stoi(dest_url.port);
+            d_ws_endpt.set_reuse_addr(true);
             d_ws_endpt.listen(dest_url.host, dest_url.port, ec);
             if (ec) {
                 fprintf(stderr, "%s op25_audio::op25_audio: port [%d], websocket listen error: %s\n", logts.get(d_msgq_id), d_ws_port, ec.message().c_str());

--- a/op25/gr-op25_repeater/lib/op25_audio.cc
+++ b/op25/gr-op25_repeater/lib/op25_audio.cc
@@ -407,7 +407,6 @@ void op25_audio::ws_send_audio_flag(const udpFlagEnumType udp_flag)
 void op25_audio::ws_start()
 {
     ws_thread = std::thread([this]() { this->d_ws_endpt.run(); });
-    ws_thread.detach();
     d_ws_enabled = true;
     fprintf(stderr, "%s op25_audio::op25_audio: Started websocket server on port %d\n", logts.get(d_msgq_id), d_ws_port);
 }
@@ -415,8 +414,9 @@ void op25_audio::ws_start()
 // websocket graceful shutdown
 void op25_audio::ws_stop()
 {
-    if (!d_ws_enabled || !ws_thread.joinable())
-        return;  // never started — destructor calls this unconditionally
+    if (!d_ws_enabled)
+        return;
+    d_ws_enabled = false;
     fprintf(stderr, "%s op25_audio::op25_audio: Shutting down websocket server on port %d\n", logts.get(d_msgq_id), d_ws_port);
     d_ws_endpt.stop_listening();
     {
@@ -424,8 +424,11 @@ void op25_audio::ws_stop()
         for (auto & hdl : d_ws_connections) {
             if ( hdl.expired() )
                 continue;
-            d_ws_endpt.close(hdl, 1001, "Shutting down");
+            websocketpp::lib::error_code ec;
+            d_ws_endpt.close(hdl, websocketpp::close::status::going_away, "Shutting down", ec);
         }
     }
-    ws_thread.join();
+    d_ws_endpt.stop();
+    if (ws_thread.joinable())
+        ws_thread.join();
 }


### PR DESCRIPTION
Another fix to op25_audio that is needed to make websocket audio to browser more reliable. I put these in their own branch to keep the frontend work separate.

## Summary

- **`ws_thread.detach()` made `ws_stop()` a no-op**: `ws_start()` was detaching
  the server thread immediately after creation, which causes `std::thread::joinable()`
  to always return `false`. Since `ws_stop()` guarded on `!ws_thread.joinable()`,
  it returned immediately without ever calling `stop_listening()`, closing connections,
  or joining the thread. The WebSocket server was never cleanly shut down on exit.

- **Port not released on restart**: Because `ws_stop()` never ran, combined with
  WebSocket connections left in `TIME_WAIT` state after process exit and `SO_REUSEADDR`
  not being explicitly set, restarting `multi_rx.py` would fail immediately with
  `Address already in use` on the WebSocket port.

## Changes (op25_audio.cc)

- **`ws_start()`**: Removed `ws_thread.detach()` so the thread remains joinable
  and can be properly joined on shutdown.
- **`ws_stop()`**: Changed guard from `!ws_thread.joinable()` to `!d_ws_enabled`;
  set `d_ws_enabled = false` at entry to prevent double-shutdown; added
  `d_ws_endpt.stop()` so `run()` returns before joining; switched `close()` to
  the error-code overload to avoid potential throws during shutdown.
- **Constructor**: Added `d_ws_endpt.set_reuse_addr(true)` before `listen()` so
  the listening socket allows immediate rebinding after restart even if prior
  connections are in `TIME_WAIT`.

## Test plan

- [ ] Start `multi_rx.py` with a WebSocket audio destination (e.g. `ws://0.0.0.0:9000`)
- [ ] Confirm WebSocket server starts on the configured port
- [ ] Press Ctrl+C to stop
- [ ] Immediately restart `multi_rx.py`
- [ ] Confirm no `Address already in use` error and WebSocket server starts cleanly
