### PR TITLE
Add WebSocket audio streaming support to browser with multi-channel independent playback

### DIFF
--- a/op25/gr-op25_repeater/www/www-static/index.html
+++ b/op25/gr-op25_repeater/www/www-static/index.html
@@ -280,6 +280,8 @@
               <br>
               <span id="streamButton" style="display: inline-block; margin: 10px;"></span>
               <!-- This will be a speaker icon with link when the c_stream_url is present -->
+              <span id="wsAudioButton" style="display: inline-block; margin: 10px;"></span>
+              <!-- Headphone icon to toggle WebSocket audio playback when ws endpoint is present -->
               <br>
               <span class="small-label">Tuning</span>
               <br>

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -2487,7 +2487,15 @@ function ws_create(channel) {
 
 //
 
-    ws_endpt = new WebSocket(ws_endpoints[channel]);
+    var ws_url = (function(endpoint) {
+        try {
+            var u = new URL(endpoint);
+            if (u.hostname === '0.0.0.0' || u.hostname === '127.0.0.1')
+                u.hostname = window.location.hostname;
+            return u.toString();
+        } catch(e) { return endpoint; }
+    })(ws_endpoints[channel]);
+    ws_endpt = new WebSocket(ws_url);
     ws_channel = channel;
     ws_endpt.binaryType = 'arraybuffer';
     console.log("WebSocket connection opened:", ws_endpt.url);

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -57,6 +57,12 @@ var default_channel = null;
 var ws_endpoints = {};
 var ws_channel = 0;
 var ws_endpt = null;
+var audioCtx = null;
+var audioQueue = [];
+var audioPlaying = false;
+var audioEnabled = false;
+var audioNextPlayTime = 0;
+const WS_AUDIO_SAMPLE_RATE = 8000;
 var enc_sym = "&#216;";
 // var presets = [];
 var site_alias = [];
@@ -570,7 +576,17 @@ function channel_status() {
     if (c_stream_url != undefined) {
         var streamHTML = "<a a href='" + c_stream_url + "' target='_blank'>&#128264;</a>";
         streamButton.innerHTML = streamHTML;
-        streamURL.innerHTML = streamHTML + " " + c_stream_url    
+        streamURL.innerHTML = streamHTML + " " + c_stream_url
+    }
+
+    // displays the headphone icon when a websocket audio endpoint is available
+    var wsAudioButton = document.getElementById("wsAudioButton");
+    if (ws_channel in ws_endpoints && ws_endpoints[ws_channel] != null) {
+        if (!audioEnabled) {
+            wsAudioButton.innerHTML = "<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;</span>";
+        }
+    } else {
+        wsAudioButton.innerHTML = "";
     }
 
 	// TODO: c_ppm is not displayed anywhere in the new UI. What is it?
@@ -2418,6 +2434,41 @@ function ws_instances(instances) {
             ws_endpoints[key] = value;			// can trigger here if something new shows up
         }
     });
+    ws_create(channel_list[channel_index]);
+}
+
+function audio_play() {
+    if (!audioCtx || !audioEnabled || audioQueue.length === 0) return;
+    if (audioNextPlayTime < audioCtx.currentTime)
+        audioNextPlayTime = audioCtx.currentTime;
+    while (audioQueue.length > 0) {
+        var samples = audioQueue.shift();
+        var buffer = audioCtx.createBuffer(1, samples.length, WS_AUDIO_SAMPLE_RATE);
+        var ch = buffer.getChannelData(0);
+        for (var i = 0; i < samples.length; i++)
+            ch[i] = samples[i] / 32768.0;
+        var source = audioCtx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(audioCtx.destination);
+        source.start(audioNextPlayTime);
+        audioNextPlayTime += buffer.duration;
+    }
+}
+
+function audio_toggle() {
+    var btn = document.getElementById("wsAudioButton");
+    if (!audioEnabled) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: WS_AUDIO_SAMPLE_RATE });
+        audioEnabled = true;
+        btn.innerHTML = "<span title='Stop audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;&#9646;&#9646;</span>";
+    } else {
+        audioEnabled = false;
+        audioQueue = [];
+        audioPlaying = false;
+        audioNextPlayTime = 0;
+        if (audioCtx) { audioCtx.close(); audioCtx = null; }
+        btn.innerHTML = "<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;</span>";
+    }
 }
 
 function ws_create(channel) {
@@ -2441,12 +2492,23 @@ function ws_create(channel) {
     ws_endpt.binaryType = 'arraybuffer';
     console.log("WebSocket connection opened:", ws_endpt.url);
 
-    ws_endpt.onmessage = function(event) {      // play the received binary audio from here
-        console.log("Message received:", event.data);
+    ws_endpt.onmessage = function(event) {
+        if (typeof event.data === 'string') {
+            var msg = JSON.parse(event.data);
+            if (msg.cmd === 'audio_drain' || msg.cmd === 'audio_drop') {
+                audioQueue = [];
+                audioPlaying = false;
+                audioNextPlayTime = 0;
+            }
+        } else if (audioEnabled && audioCtx) {
+            audioQueue.push(new Int16Array(event.data));
+            audio_play();
+        }
     };
   
     ws_endpt.onclose = function(event) {
         ws_endpt = null;
+        setTimeout(function() { ws_create(channel_list[channel_index]); }, 3000);
     };
 
     ws_endpt.onerror = function(event) {

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -55,13 +55,9 @@ var channel_list = [];
 var channel_index = 0;
 var default_channel = null;
 var ws_endpoints = {};
-var ws_channel = 0;
-var ws_endpt = null;
+var ws_connections = {};
 var audioCtx = null;
-var audioQueue = [];
-var audioPlaying = false;
-var audioEnabled = false;
-var audioNextPlayTime = 0;
+var audioChannels = {};
 const WS_AUDIO_SAMPLE_RATE = 8000;
 var enc_sym = "&#216;";
 // var presets = [];
@@ -493,7 +489,7 @@ function channel_update(d) {
         channel_status();
 		loadPresets(c_system);
 
-        ws_create(channel_list[channel_index])
+        ws_connect(channel_list[channel_index])
     }
 }
 
@@ -581,9 +577,13 @@ function channel_status() {
 
     // displays the headphone icon when a websocket audio endpoint is available
     var wsAudioButton = document.getElementById("wsAudioButton");
-    if (ws_channel in ws_endpoints && ws_endpoints[ws_channel] != null) {
-        if (!audioEnabled) {
-            wsAudioButton.innerHTML = "<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;</span>";
+    var viewed_ch = channel_list[channel_index];
+    if (viewed_ch in ws_endpoints && ws_endpoints[viewed_ch] != null) {
+        var isMuted = !(viewed_ch in audioChannels) || audioChannels[viewed_ch].muted;
+        if (isMuted) {
+            wsAudioButton.innerHTML = "<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle(" + viewed_ch + ")'>&#127911;</span>";
+        } else {
+            wsAudioButton.innerHTML = "<span title='Stop audio' style='cursor:pointer;' onclick='audio_toggle(" + viewed_ch + ")'>&#127911;&#9646;&#9646;</span>";
         }
     } else {
         wsAudioButton.innerHTML = "";
@@ -2426,23 +2426,22 @@ async function loadPresets(sysname) {
 } // end loadPresets
 
 function ws_instances(instances) {
-	Object.entries(instances).forEach(([key, value]) => {
+    Object.entries(instances).forEach(([key, value]) => {
         if (key == 'json_type')
-            return; // continue forEach loop
-
-        if (!(key in ws_endpoints) || ((key in ws_endpoints) && (ws_endpoints[key] != value))) {
-            ws_endpoints[key] = value;			// can trigger here if something new shows up
-        }
+            return;
+        if (!(key in ws_endpoints) || ws_endpoints[key] != value)
+            ws_endpoints[key] = value;
+        ws_connect(key);
     });
-    ws_create(channel_list[channel_index]);
 }
 
-function audio_play() {
-    if (!audioCtx || !audioEnabled || audioQueue.length === 0) return;
-    if (audioNextPlayTime < audioCtx.currentTime)
-        audioNextPlayTime = audioCtx.currentTime;
-    while (audioQueue.length > 0) {
-        var samples = audioQueue.shift();
+function audio_play(channel) {
+    var state = audioChannels[channel];
+    if (!audioCtx || state.muted || state.queue.length === 0) return;
+    if (state.nextPlayTime < audioCtx.currentTime)
+        state.nextPlayTime = audioCtx.currentTime;
+    while (state.queue.length > 0) {
+        var samples = state.queue.shift();
         var buffer = audioCtx.createBuffer(1, samples.length, WS_AUDIO_SAMPLE_RATE);
         var ch = buffer.getChannelData(0);
         for (var i = 0; i < samples.length; i++)
@@ -2450,42 +2449,34 @@ function audio_play() {
         var source = audioCtx.createBufferSource();
         source.buffer = buffer;
         source.connect(audioCtx.destination);
-        source.start(audioNextPlayTime);
-        audioNextPlayTime += buffer.duration;
+        source.start(state.nextPlayTime);
+        state.nextPlayTime += buffer.duration;
     }
 }
 
-function audio_toggle() {
-    var btn = document.getElementById("wsAudioButton");
-    if (!audioEnabled) {
+function audio_toggle(channel) {
+    if (!audioCtx)
         audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: WS_AUDIO_SAMPLE_RATE });
-        audioEnabled = true;
-        btn.innerHTML = "<span title='Stop audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;&#9646;&#9646;</span>";
-    } else {
-        audioEnabled = false;
-        audioQueue = [];
-        audioPlaying = false;
-        audioNextPlayTime = 0;
-        if (audioCtx) { audioCtx.close(); audioCtx = null; }
-        btn.innerHTML = "<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle()'>&#127911;</span>";
+    if (!(channel in audioChannels))
+        audioChannels[channel] = { queue: [], nextPlayTime: 0, muted: true };
+    var state = audioChannels[channel];
+    state.muted = !state.muted;
+    if (state.muted) {
+        state.queue = [];
+        state.nextPlayTime = 0;
     }
+    channel_status();
 }
 
-function ws_create(channel) {
-
-    if ((ws_endpt != null) && (ws_channel == channel) && (ws_endpt.readyState <= 1))
-        return;                                // we are already on the required channel
-
-    if ((ws_endpt != null) && (ws_endpt.readyState <= 1)) {
-        ws_endpt.close(1000, 'Closing connection normally');
+function ws_connect(channel) {
+    if ((channel in ws_connections) && ws_connections[channel] != null && ws_connections[channel].readyState <= 1)
         return;
-    }
 
-    if ((!(channel in ws_endpoints)) || (ws_endpoints[channel] == null)) {
+    if (!(channel in ws_endpoints) || ws_endpoints[channel] == null)
         return;
-    }
 
-//
+    if (!(channel in audioChannels))
+        audioChannels[channel] = { queue: [], nextPlayTime: 0, muted: true };
 
     var ws_url = (function(endpoint) {
         try {
@@ -2495,32 +2486,33 @@ function ws_create(channel) {
             return u.toString();
         } catch(e) { return endpoint; }
     })(ws_endpoints[channel]);
-    ws_endpt = new WebSocket(ws_url);
-    ws_channel = channel;
-    ws_endpt.binaryType = 'arraybuffer';
-    console.log("WebSocket connection opened:", ws_endpt.url);
 
-    ws_endpt.onmessage = function(event) {
+    var ws = new WebSocket(ws_url);
+    ws_connections[channel] = ws;
+    ws.binaryType = 'arraybuffer';
+    console.log("WebSocket audio connected for channel", channel, ":", ws.url);
+
+    ws.onmessage = function(event) {
+        var state = audioChannels[channel];
         if (typeof event.data === 'string') {
             var msg = JSON.parse(event.data);
             if (msg.cmd === 'audio_drain' || msg.cmd === 'audio_drop') {
-                audioQueue = [];
-                audioPlaying = false;
-                audioNextPlayTime = 0;
+                state.queue = [];
+                state.nextPlayTime = 0;
             }
-        } else if (audioEnabled && audioCtx) {
-            audioQueue.push(new Int16Array(event.data));
-            audio_play();
+        } else if (!state.muted && audioCtx) {
+            state.queue.push(new Int16Array(event.data));
+            audio_play(channel);
         }
     };
-  
-    ws_endpt.onclose = function(event) {
-        ws_endpt = null;
-        setTimeout(function() { ws_create(channel_list[channel_index]); }, 3000);
+
+    ws.onclose = function(event) {
+        ws_connections[channel] = null;
+        setTimeout(function() { ws_connect(channel); }, 3000);
     };
 
-    ws_endpt.onerror = function(event) {
-        console.log("WebSocket error:", event);
+    ws.onerror = function(event) {
+        console.log("WebSocket audio error for channel", channel, ":", event);
     };
 }
 


### PR DESCRIPTION
## Summary

Adds browser-based audio playback via WebSocket, allowing users to listen to
decoded audio directly in the web UI without a separate audio client.

- Each channel's `op25_audio` instance can be configured with a `ws://` destination
  (e.g. `"destination": "udp://127.0.0.1:2345, ws://0.0.0.0:9000"`) to start a
  WebSocket server that streams decoded PCM audio to connected browsers.

- The web UI automatically connects to all configured WebSocket audio endpoints
  on page load — one connection per channel, maintained independently.

- Each channel's audio is muted by default. The headphones icon (🎧) in the channel
  view toggles mute/unmute for that specific channel. Multiple channels can be
  unmuted and played simultaneously.

- The WebSocket URL is resolved relative to the web server's hostname/IP when the WS endpoint is configured to be 127.0.0.1 OR 0.0.0.0. The browser substitutes window.location.hostname automatically in these cases.

-If the host is an explicit IP like 192.168.1.100, the browser will load audio from the address as specified in the config, in case you have a reason to do it that way

- If a WebSocket connection drops, the browser automatically reconnects after 3
  seconds.

- A single shared `AudioContext` is used across all channels (created on first
  user interaction to satisfy browser autoplay policy).

## Test plan

- [ ] Configure one or more channels with a `ws://` audio destination in the
      channel config JSON
- [ ] Open the web UI and confirm WebSocket connections appear in the browser
      console for each configured channel
- [ ] Click the headphones icon on a channel and confirm audio plays
- [ ] Switch to a second channel, unmute it, confirm both channels play
      simultaneously
- [ ] Click the icon again to mute, confirm audio stops for that channel only
- [ ] Restart `multi_rx.py` and confirm the browser reconnects automatically

