### PR TITLE
Fix race condition sometimes causing 404 errors on UI plot images

### DIFF
--- a/op25/gr-op25_repeater/apps/gr_gnuplot.py
+++ b/op25/gr-op25_repeater/apps/gr_gnuplot.py
@@ -254,9 +254,10 @@ class wrap_gp(object):
         if sys.version[0] != '2':
             dat = bytes(dat, 'utf8')
         self.gp.poll()
-        if self.gp.returncode is None:  # make sure gnuplot is still running 
+        if self.gp.returncode is None:  # make sure gnuplot is still running
             try:
                 self.gp.stdin.write(dat)
+                self.gp.stdin.flush()
             except (IOError, ValueError):
                 pass
         if filename:

--- a/op25/gr-op25_repeater/apps/multi_rx.py
+++ b/op25/gr-op25_repeater/apps/multi_rx.py
@@ -949,8 +949,9 @@ class rx_block (gr.top_block):
         filenames = []
         for chan in self.channels:
             for sink in chan.sinks:
-                if chan.sinks[sink][0].gnuplot.filename is not None:
-                    filenames.append(chan.sinks[sink][0].gnuplot.filename)
+                fn = chan.sinks[sink][0].gnuplot.filename
+                if fn is not None and os.access(os.path.join(self.http_plot_directory, fn), os.R_OK):
+                    filenames.append(fn)
         d = {'json_type': 'rx_update', 'files': filenames}
         msg = gr.message().make_from_string(json.dumps(d), -4, 0, 0)
         if not self.ui_in_q.full_p():


### PR DESCRIPTION
## Summary

- Flush gnuplot's stdin pipe immediately after writing the plot command (`gr_gnuplot.py`) so gnuplot receives the command before the filename is advertised to the browser
- Gate the filename on the file actually existing on disk (`multi_rx.py`) closing the remaining window where gnuplot has received the command but hasn't finished writing the PNG

## Problem

On a system with low/limited resources, gnuplot sometimes does not finish writing the png files before the browser requests them through an HTTP GET.

When using the web UI spectrum/constellation plots in `multi_rx.py`, 404 errors appear in stderr for plot image requests like:
```
404 ../www/images/plot-0-fft-124.png
404 ../www/images/plot-0-constellation-116.png
```
A few plots can sometimes appear initially, then 404s begin to pile up. The root cause is a race condition: Python writes the plot command to gnuplot's stdin pipe (unbuffered/unflushed), immediately sets `self.filename`, and the browser's 1-second poll picks up that filename and requests it before gnuplot has had a chance to write the PNG to disk.
