### PR TITLE
Display conventional P25 channel information in web UI alongside trunked channels

### DIFF
--- a/op25/gr-op25_repeater/apps/tk_p25.py
+++ b/op25/gr-op25_repeater/apps/tk_p25.py
@@ -155,10 +155,16 @@ class rx_ctl(object):
         else:                            # undefined or mis-configured trunking sysname
             sys.stderr.write("Receiver '%s' configured with unknown trunking_sysname '%s'\n" % (rx_name, rx_sysname))
 
-        self.receivers[msgq_id] = {'msgq_id': msgq_id,
-                                   'config' : config,
-                                   'sysname': rx_sysname,
-                                   'rx_rcvr': rx_rcvr}
+        conv_state = None
+        if rx_rcvr is None:
+            conv_state = {'tgid': None, 'srcaddr': 0, 'encrypted': 0,
+                          'tag': 'Conventional', 'srctag': '', 'freq': freq, 'call_start': None}
+
+        self.receivers[msgq_id] = {'msgq_id':    msgq_id,
+                                   'config' :    config,
+                                   'sysname':    rx_sysname,
+                                   'rx_rcvr':    rx_rcvr,
+                                   'conv_state': conv_state}
 
     # post_init is called once after all receivers have been created
     def post_init(self):
@@ -196,6 +202,51 @@ class rx_ctl(object):
 
                 # Check for control channel reassignment
                 self.check_cc_assignments()
+
+        elif m_rxid in self.receivers and self.receivers[m_rxid]['conv_state'] is not None:
+            cs = self.receivers[m_rxid]['conv_state']
+            if self.debug >= 5:
+                sys.stderr.write("%s [%d] conv process_qmsg: type(%d)\n" % (log_ts.get(), m_rxid, m_type))
+            if m_type == -1:                                        # channel idle/timeout
+                cs['tgid']       = None
+                cs['srcaddr']    = 0
+                cs['encrypted']  = 0
+                cs['tag']        = 'Conventional'
+                cs['srctag']     = ''
+                cs['call_start'] = None
+                updated += 1
+            elif m_type == -3:                                      # P25 call data (srcaddr, grpaddr, encryption)
+                js = json.loads(msg.to_string())
+                grpaddr   = from_dict(js, 'grpaddr',   0)
+                srcaddr   = from_dict(js, 'srcaddr',   0)
+                encrypted = from_dict(js, 'encrypted', 0)
+                if self.debug >= 5:
+                    sys.stderr.write("%s [%d] conv call data: grpaddr(%d) srcaddr(%d) encrypted(%d)\n" % (log_ts.get(), m_rxid, grpaddr, srcaddr, encrypted))
+                if grpaddr != 0:
+                    if cs['call_start'] is None or grpaddr != cs['tgid']:   # new call started
+                        self.log_call(0, m_rxid, cs['freq'], 0, 0, grpaddr, '', srcaddr, '')
+                        cs['call_start'] = curr_time
+                        cs['tgid']       = grpaddr
+                    cs['srcaddr']   = srcaddr
+                    cs['encrypted'] = max(0, encrypted)
+                    updated += 1
+            elif m_type == 19:                                      # FDMA LCW — carries real TGID/srcaddr for conventional calls
+                s = msg.to_string()
+                lcw = s[2:]                                         # strip 2-byte NAC prefix
+                pb_sf_lco = get_ordinals(lcw[0:1])
+                if not (pb_sf_lco & 0x80):                          # skip encrypted LCW format
+                    if pb_sf_lco == 0x00:                           # Group Voice Channel User
+                        ga = get_ordinals(lcw[4:6])
+                        sa = get_ordinals(lcw[6:9])
+                        if self.debug >= 5:
+                            sys.stderr.write("%s [%d] conv lcw(0x00): ga(%d) sa(%d)\n" % (log_ts.get(), m_rxid, ga, sa))
+                        if ga != 0:
+                            if cs['call_start'] is None or ga != cs['tgid']:
+                                self.log_call(0, m_rxid, cs['freq'], 0, 0, ga, '', sa, '')
+                                cs['call_start'] = curr_time
+                                cs['tgid']       = ga
+                            cs['srcaddr'] = sa
+                            updated += 1
 
         if curr_time > (self.cleanup_timer + CLEANUP_TIMER):
             for rcvr in self.receivers:
@@ -252,10 +303,32 @@ class rx_ctl(object):
         d = {'json_type': 'channel_update'}
         rcvr_ids = []
         for rcvr in self.receivers:
+            rcvr_name = from_dict(self.receivers[rcvr]['config'], 'name', "")
             if self.receivers[rcvr]['rx_rcvr'] is not None:
-                rcvr_name = from_dict(self.receivers[rcvr]['config'], 'name', "")
                 d[str(rcvr)] = json.loads(self.receivers[rcvr]['rx_rcvr'].get_status())
                 d[str(rcvr)]['name'] = rcvr_name
+                rcvr_ids.append(str(rcvr))
+            elif self.receivers[rcvr]['conv_state'] is not None:
+                cs = self.receivers[rcvr]['conv_state']
+                sysname = from_dict(self.receivers[rcvr]['config'], 'trunking_sysname', '') or rcvr_name
+                d[str(rcvr)] = {
+                    'freq':         cs['freq'],
+                    'tdma':         0,
+                    'tgid':         cs['tgid'],
+                    'system':       sysname,
+                    'tag':          cs['tag'],
+                    'srcaddr':      cs['srcaddr'],
+                    'svcopts':      0,
+                    'srctag':       cs['srctag'],
+                    'encrypted':    cs['encrypted'],
+                    'emergency':    0,
+                    'hold_tgid':    0,
+                    'mode':         None,
+                    'stream':       from_dict(self.receivers[rcvr]['config'], 'meta_stream_name', ''),
+                    'msgqid':       rcvr,
+                    'name':         rcvr_name,
+                    'conventional': True,
+                }
                 rcvr_ids.append(str(rcvr))
         d['channels'] = rcvr_ids
         return json.dumps(d)

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -419,7 +419,12 @@ function channel_update(d) {
             capture_active = d[c_id]['capture'];
             hold_tgid = d[c_id]['hold_tgid'];
 
-            
+            if (d[c_id]['conventional'] === true) {
+                document.getElementById('frequenciesTable').innerHTML = '';
+                document.getElementById('adjacentSitesContainer').style.display = 'none';
+                document.getElementById('patchesContainer').style.display = 'none';
+            }
+
         if (hold_tgid != 0) {
             document.getElementById("btn-hold").style.color = "red";
 		} else {
@@ -1499,7 +1504,7 @@ function call_log(d) {
 			const time = `${hh}:${mm}:${ss}`;
 		
 			// Assign remaining fields to variables
-			const sysid = log.sysid.toString(16).toUpperCase().padStart(3, '0');
+			const sysid = (log.sysid != null ? log.sysid : 0).toString(16).toUpperCase().padStart(3, '0');
 			const tgid = log.tgid;
 			const tgtag = log.tgtag;
 			  var rid = log.rid;


### PR DESCRIPTION
## Summary

When `cfg.json` contains a mix of trunked and conventional P25 channels, the web UI previously only displayed channels managed by the trunking system(s). Conventional channels (those whose `trunking_sysname` does not match any configured trunking system, or empty) were invisible to `get_chan_status()` and absent from the channel table and detail view.

This PR adds live conventional channel support to `tk_p25.py` and fixes a resulting stale-data display issue in `main.js`.

### `tk_p25.py`

- **`add_receiver()`**: when a receiver has no `p25_receiver` (conventional channel), a `conv_state` dict is initialized to track live call state: `tgid`, `srcaddr`, `encrypted`, `tag`, `srctag`, `freq`, `call_start`.

- **`process_qmsg()`**: added an `elif` branch for receivers where `conv_state is not None`. Three message types are handled:
  - `m_type == -1` (idle/timeout): clears call state, resets tag to `'Conventional'`
  - `m_type == -3` (P25 call data from HDU): updates `conv_state` if `grpaddr != 0`. On conventional channels the HDU typically carries `grpaddr=0`, so the LCW handler below is the primary data source.
  - `m_type == 19` (FDMA LCW, opcode `0x00` — Group Voice Channel User): parses the Link Control Word embedded in each LDU2 frame to extract the real group address and source unit ID. This is the reliable source of TGID and srcaddr for conventional P25 calls.
  - New calls are logged via `log_call()` so they appear in server-side call history.

- **`get_chan_status()`**: now includes conventional channels alongside trunked channels in the returned JSON, using `conv_state` for live call fields. Includes a `'conventional': True` flag so the UI can identify these channels.

### `main.js`

- **`channel_update()`**: when the selected channel has `conventional === true`, trunking-specific panels (system frequencies table, adjacent sites, patches) are immediately cleared and hidden. Without this, stale data from a previously selected trunked channel persists in those panels.

- **`call_log()`**: guard against `null` sysid to prevent a `TypeError` crash when rendering call history entries for conventional channel calls.

## Test plan

- [ ] Configure `cfg.json` with at least one trunked P25 system and one conventional P25 channel (no matching `trunking_sysname`)
- [ ] Confirm conventional channel appears in the channel table alongside trunked channels
- [ ] Switch to conventional channel — verify frequency, channel name, and system name display correctly; trunking panels (adjacent sites, patches, frequency table) are hidden
- [ ] With active P25 traffic on the conventional channel, confirm TGID and source unit ID populate in the channel detail view
- [ ] Confirm conventional channel calls appear in call history (both "frequency" and "Voice Grants" sources)
- [ ] Switch back to a trunked channel — verify trunking panels repopulate normally on next update

