### PR TITLE
Add Null Guard in main.js to protect against missing trunking key

### DIFF
--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -2538,7 +2538,7 @@ function ws_connect(channel) {
 
 function full_config(config) {
 
-	var sa = config['trunking']['chans'];
+	var sa = config['trunking'] ? config['trunking']['chans'] : [];
 	site_alias = buildSiteAliases(sa);
 
     // some payloads are sending over full_config when it's not requested (plots) and not needed.


### PR DESCRIPTION
## Summary

- `full_config()` in `main.js` unconditionally reads `config['trunking']['chans']`, crashing with a `TypeError` when no `trunking` key is present in the config JSON
- This broke WebSocket audio for conventional-only configs after the recent change to make `tk_p25.py` the default trunking module (the upstream default fires precisely when there is no `trunking` section, so the server-side JSON response has no `trunking` key)
- Fix: null-guard the access with `config['trunking'] ? config['trunking']['chans'] : []`
- `buildSiteAliases()` already handles an empty array gracefully, so passing `[]` is safe

## Test plan

- [ ] Run `multi_rx.py` with a config that has no `trunking` section — confirm no JS error in browser console and WebSocket audio connects normally
- [ ] Run with a config that has a populated `trunking` section — confirm site alias behaviour is unchanged
