### PR TITLE
Web UI: channel auto-focus, click-to-select, and call history dedup fixes

### DIFF
--- a/op25/gr-op25_repeater/www/www-static/index.html
+++ b/op25/gr-op25_repeater/www/www-static/index.html
@@ -228,6 +228,8 @@
               <br>
               <button class="button-3d" onclick="f_scan_button('goto'); this.blur();">GO TO</button>
               <br>
+              <button class="button-3d" id="btn-auto-focus" onclick="toggle_auto_focus(); this.blur();">AUTO FOCUS: on</button>
+              <br>
             </td>
             <!-- Main info area -->
             <td class="main-info">

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -96,6 +96,7 @@ var TG_TAG_CACHE = {}; // { "1A2": { "1234": "PD Dispatch", ... }, ... }
 
 // stores the time a tg was last seen so duplicates are avoided in the call history table
 var callHistorySeen = new Map(); // key -> lastSeenMs
+var callLogSeen = new Map();     // key -> lastSeenMs, for Voice Grant (Python) dedup
 
 // stores sort params for the seen talkgroup table popup
 var SEEN_TG_SORT = { col: null, asc: true };
@@ -1562,6 +1563,13 @@ function call_log(d) {
 				
 			if (rid == 0)
 				return;  // srcaddr not yet known; a follow-up log entry with the real ID will arrive
+
+			const logKey = sysid + "|" + tgid + "|" + rid;
+			const nowMs = Date.now();
+			const ttlMs = (Number(MAX_HISTORY_SECONDS) || 5) * 1000;
+			if (callLogSeen.has(logKey) && (nowMs - callLogSeen.get(logKey)) <= ttlMs)
+				return;
+			callLogSeen.set(logKey, nowMs);
 
 			displayRtag = (rtag !== "") ? rtag : "ID: " + rid;
 			displayTtag = (tgtag !== "") ? tgtag : "Talkgroup " + tgid;

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -1925,8 +1925,12 @@ function appendCallHistory(sysid, tg1, tg2, tag1, tag2, freq, sourceId1, sourceI
   var epochMs = now.getTime();
 
   // Normalize sysid -> 3-digit hex
-  var sysHex = Number(sysid).toString(16).toUpperCase().padStart(3, "0");
+  var sysNum = Number(sysid);
 
+  var sysHex = (!isNaN(sysNum) && sysid !== null && sysid !== "")
+    ? sysNum.toString(16).toUpperCase().padStart(3, "0")
+    : "-";
+    
   // helpers
   function cleanStr(v) {
     if (v === undefined || v === null) return "";

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -1375,15 +1375,14 @@ if (hasValue(tg2)) {
 				? srctag1
 				: (src1 != null && String(src1).trim() !== "" && Number(src1) !== 0)
 					? `ID: ${src1}`
-					: "-";
-			
+					: null;
+
 			let source2 =
 			  (srctag2 != null && String(srctag2).trim() !== "")
 				? srctag2
 				: (src2 != null && String(src2).trim() !== "" && Number(src2) !== 0)
 					? `ID: ${src2}`
-					: `ID: ${src1}` 	// there may be a bug python side that causes the ID for srctag[1] to show up in [0] when
-								    	// a tgtag is not present python side.
+					: null;
 			
 			
 			
@@ -2043,9 +2042,8 @@ function processLeg(tg, tag, src, method) {
   markSeen(tgStr, srcStr);
 }
 
-  // Process both legs (even if equal — you can decide whether to suppress same TG)
   processLeg(tg1, tag1, sourceId1, "tg1");
-  processLeg(tg2, tag2, sourceId2, "tg2");
+  if (String(tg2) !== String(tg1)) processLeg(tg2, tag2, sourceId2, "tg2");
 
 
   applySmartColorsToCallHistory();

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -1561,8 +1561,8 @@ function call_log(d) {
 			  var slot = log.slot;
 				
 			if (rid == 0)
-				rid = "-";
-			
+				return;  // srcaddr not yet known; a follow-up log entry with the real ID will arrive
+
 			displayRtag = (rtag !== "") ? rtag : "ID: " + rid;
 			displayTtag = (tgtag !== "") ? tgtag : "Talkgroup " + tgid;
 			

--- a/op25/gr-op25_repeater/www/www-static/main.js
+++ b/op25/gr-op25_repeater/www/www-static/main.js
@@ -53,6 +53,7 @@ var c_nac = 0;
 var c_name = "";
 var channel_list = [];
 var channel_index = 0;
+var auto_focus = true;       // when true, channel view follows the active call automatically
 var lastChannelData = null;
 var default_channel = null;
 var ws_endpoints = {};
@@ -382,6 +383,37 @@ function channel_update(d) {
                 default_channel = null;
             }
 
+            // Auto-focus: prefer slot with an active call, fall back to hold, then CC.
+            // Voice pool channels occupy indices 1+ in channel_list (CC is always index 0).
+            // Pass 1: slot with current_tgid set — radio is actively transmitting right now.
+            // Pass 2: slot with merged tgid set — call just ended but still in hold period.
+            // Pass 3: all idle — show CC (slot 0).
+            // Skipped entirely when auto_focus=false (toggled off via the AUTO button).
+            if (auto_focus) {
+                var _auto_voice = false;
+                for (var _vi = 1; _vi < channel_list.length; _vi++) {
+                    var _vid = channel_list[_vi];
+                    if (d[_vid] && d[_vid]['current_tgid'] !== null && d[_vid]['current_tgid'] !== undefined) {
+                        channel_index = _vi;
+                        _auto_voice = true;
+                        break;
+                    }
+                }
+                if (!_auto_voice) {
+                    for (var _vi = 1; _vi < channel_list.length; _vi++) {
+                        var _vid = channel_list[_vi];
+                        if (d[_vid] && d[_vid]['tgid'] !== null && d[_vid]['tgid'] !== undefined) {
+                            channel_index = _vi;
+                            _auto_voice = true;
+                            break;
+                        }
+                    }
+                }
+                if (!_auto_voice) {
+                    channel_index = 0;
+                }
+            }
+
             // display channel information
             var c_id = channel_list[channel_index];
             c_system = d[c_id]['system'];
@@ -559,13 +591,13 @@ function channel_table(d) {
 		const isMuted = !(ch in audioChannels) || audioChannels[ch].muted;
 		const audioIcon = hasAudio
 			? (isMuted
-				? `<span title='Play audio' style='cursor:pointer;' onclick='audio_toggle(${ch})'>&#9654;</span>`
-				: `<span title='Stop audio' style='cursor:pointer;' onclick='audio_toggle(${ch})'>&#9646;&#9646;</span>`)
+				? `<span title='Play audio' style='cursor:pointer;' onclick='event.stopPropagation(); audio_toggle(${ch})'>&#9654;</span>`
+				: `<span title='Stop audio' style='cursor:pointer;' onclick='event.stopPropagation(); audio_toggle(${ch})'>&#9646;&#9646;</span>`)
 			: "";
 
-		html += `<tr>
-			<td${tdc} title='Channel ${ch}' style='cursor:pointer;' onclick='f_chan_direct(${ch})'>${ch}</td>
-			<td${tdc} title='${name} 'style='cursor:pointer;' onclick='f_chan_direct(${ch})'>${name}</td>
+		html += `<tr style='cursor:pointer;' onclick='select_channel_by_id(${ch})'>
+			<td${tdc}>${ch}</td>
+			<td>${name}</td>
 			<td style='text-align:center;'>${audioIcon}</td>
 			<td>${system}</td>
 			<td>${freq}</td>
@@ -1669,8 +1701,8 @@ async function send_process() {
     }
 }
 
-function f_chan_direct(command) {
-    channel_index = command;
+function f_chan_button(command) {
+    channel_index += command;
     if (channel_index < 0) {
         channel_index = channel_list.length - 1;
     }
@@ -1679,13 +1711,27 @@ function f_chan_direct(command) {
     }
 }
 
-function f_chan_button(command) {
-    channel_index += command;
-    if (channel_index < 0) {
-        channel_index = channel_list.length - 1;
+function select_channel_by_id(ch_id) {
+    var idx = channel_list.indexOf(String(ch_id));
+    if (idx >= 0) {
+        channel_index = idx;
     }
-    else if (channel_index >= channel_list.length) {
-        channel_index = 0;
+}
+
+function toggle_auto_focus() {
+    auto_focus = !auto_focus;
+    update_auto_btn();
+}
+
+function update_auto_btn() {
+    var btn = document.getElementById('btn-auto-focus');
+    if (!btn) return;
+    if (auto_focus) {
+        btn.textContent = 'AUTO FOCUS: on';
+        btn.style.color = '';
+    } else {
+        btn.textContent = 'AUTO FOCUS: off';
+        btn.style.color = '#f80';
     }
 }
 
@@ -1879,11 +1925,7 @@ function appendCallHistory(sysid, tg1, tg2, tag1, tag2, freq, sourceId1, sourceI
   var epochMs = now.getTime();
 
   // Normalize sysid -> 3-digit hex
-  var sysNum = Number(sysid);
-
-  var sysHex = (!isNaN(sysNum) && sysid !== null && sysid !== "")
-    ? sysNum.toString(16).toUpperCase().padStart(3, "0")
-    : "-";
+  var sysHex = Number(sysid).toString(16).toUpperCase().padStart(3, "0");
 
   // helpers
   function cleanStr(v) {


### PR DESCRIPTION
Channel auto-focus — The main channel view now automatically follows the active voice call. When a call is active, the display switches to that voice channel. When all channels go idle, it falls back to the first channel. A new AUTO FOCUS button in the left panel lets the user toggle this behavior on or off; the button turns orange when disabled.

Click-to-select in channel table — Each row in the channel table is now clickable to manually focus that channel. event.stopPropagation() is added to the per-channel audio toggle icons so clicking play/pause doesn't also trigger the row selection.

Voice grant history cleanup:

Premature log entries with no source ID — log_call fires at voice grant time before the HDU has decoded the source radio ID, producing a row with rid=0. These entries are now skipped; a follow-up log_call with the real source ID always arrives when the HDU is processed.

Double entries on encrypted calls — For encrypted calls, log_call was firing from both the TSBK grant and the HDU with the same non-zero srcaddr, producing two identical rows. A deduplication map (keyed on sysid|tgid|rid, TTL 5 s) now suppresses the second entry.

Duplicate rows from the frequency table source — When using the frequency data source, FDMA calls were producing two rows because the tg2 leg was always processed even when tg2 == tg1. The second processLeg call is now skipped for FDMA. The source1/source2 fallbacks are also fixed to return null instead of "-" or ID: ${src1} when no valid source address is present, preventing premature rows before the real source ID is known.